### PR TITLE
fix(seguridad): aplicar las policies de dominio en los endpoints que las salteaban

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@nestjs/cli": "^10.4.5",
     "@nestjs/testing": "^10.4.0",
+    "@swc/core": "^1.16.0",
     "@types/express": "^5.0.6",
     "@types/pg": "^8.11.0",
     "@types/supertest": "^6.0.2",
@@ -50,6 +51,7 @@
     "testcontainers": "^10.13.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.0",
+    "unplugin-swc": "^1.5.11",
     "vitest": "^2.1.0"
   }
 }

--- a/apps/api/src/auth/jwt.service.ts
+++ b/apps/api/src/auth/jwt.service.ts
@@ -48,6 +48,12 @@ export class JwtService {
       if (typeof payload.sub !== 'string' || typeof payload.kind !== 'string') {
         throw new UnauthorizedException('invalid token payload');
       }
+      // Un refresh NO sirve como access. Ambos se firman con el mismo secreto,
+      // así que sin este chequeo el token de 7 días funcionaba como bearer:
+      // uno robado del navegador valía una semana en vez de 15 minutos.
+      if (payload.typ === 'refresh') {
+        throw new UnauthorizedException('refresh token no válido como access');
+      }
       return {
         sub: payload.sub,
         kind: payload.kind as UserKind,

--- a/apps/api/src/common/residente-ctx.ts
+++ b/apps/api/src/common/residente-ctx.ts
@@ -1,0 +1,42 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import type { ResidenteCtx } from '@consorciofix/domain';
+import { unidad, vinculoResidente } from '../db/schema/index.js';
+import type { TxClient } from '../db/client.js';
+
+/**
+ * Resuelve el contexto row-level de un residente: en qué unidades tiene
+ * vínculo activo y, por transitividad, a qué consorcios pertenece.
+ *
+ * Es el input de `canResidenteSeeTicket` / `canResidenteSeeCosto`
+ * (packages/domain). Vivía duplicado en MeService y VotosService, y esa
+ * duplicación es justamente lo que permitió que otros handlers se olvidaran
+ * de aplicarlo: centralizarlo hace que agregar el chequeo sea una línea.
+ */
+export async function loadResidenteCtx(
+  tx: TxClient,
+  tenantId: string,
+  residenteId: string,
+): Promise<ResidenteCtx> {
+  const vinculos = await tx
+    .select({ unidadId: vinculoResidente.unidadId })
+    .from(vinculoResidente)
+    .where(
+      and(
+        eq(vinculoResidente.tenantId, tenantId),
+        eq(vinculoResidente.residenteId, residenteId),
+        eq(vinculoResidente.activo, true),
+      ),
+    );
+  const unidadIds = new Set(vinculos.map((v) => v.unidadId));
+
+  let consorcioIds = new Set<string>();
+  if (unidadIds.size > 0) {
+    const unidades = await tx
+      .select({ consorcioId: unidad.consorcioId })
+      .from(unidad)
+      .where(inArray(unidad.id, Array.from(unidadIds)));
+    consorcioIds = new Set(unidades.map((u) => u.consorcioId));
+  }
+
+  return { residenteId, consorcioIds, unidadIds };
+}

--- a/apps/api/src/gastos/gastos.controller.ts
+++ b/apps/api/src/gastos/gastos.controller.ts
@@ -2,7 +2,14 @@ import { Body, Controller, ForbiddenException, Get, Param, Post, Req } from '@ne
 import { z } from 'zod';
 import type { AuthedRequest } from '../auth/auth.guard.js';
 import { Roles } from '../auth/roles.guard.js';
-import { GastosService } from './gastos.service.js';
+import { GastosService, type GastoViewer } from './gastos.service.js';
+
+function viewer(req: AuthedRequest): GastoViewer {
+  const kind = req.user?.kind;
+  if (kind === 'RESIDENTE') return { kind, residenteId: req.user!.sub };
+  if (kind === 'ADMIN' || kind === 'SUPER_ADMIN') return { kind };
+  throw new ForbiddenException('no user context');
+}
 
 const CreateGastoBody = z.object({
   descripcion: z.string().min(1).max(280),
@@ -28,14 +35,20 @@ function tid(req: AuthedRequest): string {
 export class GastosController {
   constructor(private readonly gastos: GastosService) {}
 
+  /**
+   * El rol va explícito: sin metadata, RolesGuard deja pasar a cualquier
+   * autenticado. Para RESIDENTE el service aplica G10 y filtra a CONFIRMADO.
+   */
+  @Roles('SUPER_ADMIN', 'ADMIN', 'RESIDENTE')
   @Get()
   async list(@Req() req: AuthedRequest, @Param('ticketId') ticketId: string) {
-    return this.gastos.list(tid(req), ticketId);
+    return this.gastos.list(tid(req), ticketId, viewer(req));
   }
 
+  @Roles('SUPER_ADMIN', 'ADMIN', 'RESIDENTE')
   @Get('total')
   async total(@Req() req: AuthedRequest, @Param('ticketId') ticketId: string) {
-    return this.gastos.totalConfirmado(tid(req), ticketId);
+    return this.gastos.totalConfirmado(tid(req), ticketId, viewer(req));
   }
 
   @Roles('SUPER_ADMIN', 'ADMIN')

--- a/apps/api/src/gastos/gastos.service.ts
+++ b/apps/api/src/gastos/gastos.service.ts
@@ -1,7 +1,14 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { and, desc, eq, sql } from 'drizzle-orm';
+import { canResidenteSeeCosto } from '@consorciofix/domain';
 import { gasto, ticket } from '../db/schema/index.js';
 import { withTenant } from '../db/client.js';
+import { loadResidenteCtx } from '../common/residente-ctx.js';
+
+/** Quién consulta los costos. Un RESIDENTE queda sujeto a G10. */
+export type GastoViewer =
+  | { kind: 'SUPER_ADMIN' | 'ADMIN' }
+  | { kind: 'RESIDENTE'; residenteId: string };
 
 export interface CreateGastoInput {
   descripcion: string;
@@ -13,19 +20,41 @@ export interface CreateGastoInput {
 
 @Injectable()
 export class GastosService {
-  async list(tenantId: string, ticketId: string) {
+  /**
+   * Gastos de un ticket.
+   *
+   * Para un RESIDENTE se aplica G10 (`canResidenteSeeCosto`: solo espacios
+   * comunes) y se fuerza `estado = CONFIRMADO`. El BORRADOR existe justamente
+   * para que el admin cargue montos tentativos sin publicarlos, así que
+   * exponerlo —junto con la URL del comprobante— era una fuga doble.
+   */
+  async list(tenantId: string, ticketId: string, viewer: GastoViewer) {
     return withTenant(tenantId, async (tx) => {
-      const exists = await tx
-        .select({ id: ticket.id })
-        .from(ticket)
-        .where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, ticketId)))
-        .limit(1);
-      if (!exists[0]) throw new NotFoundException('ticket not found');
-      return tx
-        .select()
-        .from(gasto)
-        .where(and(eq(gasto.tenantId, tenantId), eq(gasto.ticketId, ticketId)))
-        .orderBy(desc(gasto.createdAt));
+      const t = (
+        await tx
+          .select()
+          .from(ticket)
+          .where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, ticketId)))
+          .limit(1)
+      )[0];
+      if (!t) throw new NotFoundException('ticket not found');
+
+      const conds = [eq(gasto.tenantId, tenantId), eq(gasto.ticketId, ticketId)];
+
+      if (viewer.kind === 'RESIDENTE') {
+        const ctx = await loadResidenteCtx(tx, tenantId, viewer.residenteId);
+        const puede = canResidenteSeeCosto(ctx, {
+          tipo: t.tipo,
+          origen: t.origen,
+          unidadId: t.unidadId,
+          consorcioId: t.consorcioId,
+        });
+        // 404 y no 403: un 403 confirmaría que el ticket existe.
+        if (!puede) throw new NotFoundException('ticket not found');
+        conds.push(eq(gasto.estado, 'CONFIRMADO'));
+      }
+
+      return tx.select().from(gasto).where(and(...conds)).orderBy(desc(gasto.createdAt));
     });
   }
 
@@ -57,8 +86,31 @@ export class GastosService {
     });
   }
 
-  async totalConfirmado(tenantId: string, ticketId: string): Promise<{ moneda: string; total: number }[]> {
+  async totalConfirmado(
+    tenantId: string,
+    ticketId: string,
+    viewer: GastoViewer,
+  ): Promise<{ moneda: string; total: number }[]> {
     return withTenant(tenantId, async (tx) => {
+      if (viewer.kind === 'RESIDENTE') {
+        const t = (
+          await tx
+            .select()
+            .from(ticket)
+            .where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, ticketId)))
+            .limit(1)
+        )[0];
+        if (!t) throw new NotFoundException('ticket not found');
+        const ctx = await loadResidenteCtx(tx, tenantId, viewer.residenteId);
+        const puede = canResidenteSeeCosto(ctx, {
+          tipo: t.tipo,
+          origen: t.origen,
+          unidadId: t.unidadId,
+          consorcioId: t.consorcioId,
+        });
+        if (!puede) throw new NotFoundException('ticket not found');
+      }
+
       const rows = await tx
         .select({
           moneda: gasto.moneda,

--- a/apps/api/src/tickets/tickets.controller.ts
+++ b/apps/api/src/tickets/tickets.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Delete, ForbiddenException, Get, Param, Post, Query, 
 import { z } from 'zod';
 import { Roles } from '../auth/roles.guard.js';
 import type { AuthedRequest } from '../auth/auth.guard.js';
-import { TicketsService } from './tickets.service.js';
+import { TicketsService, type TicketViewer } from './tickets.service.js';
 import { VotosService } from './votos.service.js';
 
 const CreateTicketBody = z.object({
@@ -27,6 +27,13 @@ const ListQuery = z.object({
   consorcio_id: z.string().uuid().optional(),
   estado: z.enum(['REGISTRADO', 'VALIDADO', 'DESCARTADO', 'SOLUCIONADO']).optional(),
 });
+
+function viewer(req: AuthedRequest): TicketViewer {
+  const kind = req.user?.kind;
+  if (kind === 'RESIDENTE') return { kind, residenteId: req.user!.sub };
+  if (kind === 'ADMIN' || kind === 'SUPER_ADMIN') return { kind };
+  throw new ForbiddenException('no user context');
+}
 
 function tid(req: AuthedRequest): string {
   const headerTid = req.headers['x-tenant-id'];
@@ -70,9 +77,15 @@ export class TicketsController {
     });
   }
 
+  /**
+   * El rol se declara explícitamente porque RolesGuard deja pasar a cualquier
+   * autenticado cuando el handler no tiene metadata. La visibilidad fina para
+   * RESIDENTE la resuelve el service con la matriz de `packages/domain`.
+   */
+  @Roles('SUPER_ADMIN', 'ADMIN', 'RESIDENTE')
   @Get(':id')
   async one(@Req() req: AuthedRequest, @Param('id') id: string) {
-    return this.tickets.byId(tid(req), id);
+    return this.tickets.byId(tid(req), id, viewer(req));
   }
 
   @Roles('SUPER_ADMIN', 'ADMIN')

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -1,11 +1,17 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { and, desc, eq } from 'drizzle-orm';
-import { assertTransition, type TicketState } from '@consorciofix/domain';
-import { ticket, ticketEvento } from '../db/schema/index.js';
+import { assertTransition, canResidenteSeeTicket, type TicketState } from '@consorciofix/domain';
+import { ticket, ticketEvento, unidad } from '../db/schema/index.js';
 import type { TxClient } from '../db/client.js';
 import { db, withTenant } from '../db/client.js';
+import { loadResidenteCtx } from '../common/residente-ctx.js';
 import { AuditService } from '../audit/audit.service.js';
 import { NotificationsService } from '../notifications/notifications.service.js';
+
+/** Quién pide el recurso. Un RESIDENTE queda sujeto a la matriz row-level. */
+export type TicketViewer =
+  | { kind: 'SUPER_ADMIN' | 'ADMIN' }
+  | { kind: 'RESIDENTE'; residenteId: string };
 
 export interface CreateTicketInput {
   consorcioId: string;
@@ -36,6 +42,34 @@ export class TicketsService {
           .where(and(eq(ticket.tenantId, tenantId), eq(ticket.clientGeneratedId, input.clientGeneratedId)))
           .limit(1);
         if (existing[0]) return existing[0];
+      }
+
+      // Pertenencia (RF-H03): el reportante solo puede crear tickets en un
+      // consorcio donde tenga vínculo activo, y la unidad imputada debe
+      // pertenecer a ese consorcio. Sin esto un residente podía crear tickets
+      // —incluso de CONDUCTA— en consorcios ajenos, imputando cualquier unidad.
+      //
+      // Ojo: NO se exige que sea ocupante de `unidadId`. En CONDUCTA la unidad
+      // es justamente la del vecino denunciado, y en infraestructura uno puede
+      // reportar la filtración de otra unidad. El consorcio es el límite real.
+      if (input.reportanteId) {
+        const ctx = await loadResidenteCtx(tx, tenantId, input.reportanteId);
+        if (!ctx.consorcioIds.has(input.consorcioId)) {
+          throw new ForbiddenException('sin vínculo activo en ese consorcio');
+        }
+        if (input.unidadId) {
+          const u = (
+            await tx
+              .select({ consorcioId: unidad.consorcioId })
+              .from(unidad)
+              .where(and(eq(unidad.tenantId, tenantId), eq(unidad.id, input.unidadId)))
+              .limit(1)
+          )[0];
+          if (!u) throw new BadRequestException('unidad inexistente');
+          if (u.consorcioId !== input.consorcioId) {
+            throw new BadRequestException('la unidad no pertenece a ese consorcio');
+          }
+        }
       }
 
       const inserted = await tx
@@ -69,12 +103,37 @@ export class TicketsService {
     });
   }
 
-  async byId(tenantId: string, id: string) {
+  /**
+   * Detalle de un ticket.
+   *
+   * Para un RESIDENTE aplica la misma matriz row-level que el feed
+   * (`canResidenteSeeTicket`) y proyecta el resultado ocultando la identidad
+   * del reportante en tickets de CONDUCTA (RF-F02). Sin esto el endpoint
+   * devolvía la fila cruda a cualquier autenticado: un residente podía leer
+   * cualquier ticket del tenant —incluso de otro consorcio— y, en conducta,
+   * averiguar quién lo denunció.
+   *
+   * Cuando el ticket existe pero no es visible se responde 404 y no 403:
+   * un 403 confirmaría su existencia, que ya es información.
+   */
+  async byId(tenantId: string, id: string, viewer: TicketViewer) {
     return withTenant(tenantId, async (tx) => {
       const rows = await tx.select().from(ticket).where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, id))).limit(1);
       const t = rows[0];
       if (!t) throw new NotFoundException('ticket not found');
-      return t;
+
+      if (viewer.kind !== 'RESIDENTE') return t;
+
+      const ctx = await loadResidenteCtx(tx, tenantId, viewer.residenteId);
+      const visible = canResidenteSeeTicket(ctx, {
+        tipo: t.tipo,
+        origen: t.origen,
+        unidadId: t.unidadId,
+        consorcioId: t.consorcioId,
+      });
+      if (!visible) throw new NotFoundException('ticket not found');
+
+      return { ...t, reportanteId: t.tipo === 'CONDUCTA' ? null : t.reportanteId };
     });
   }
 

--- a/apps/api/src/tickets/votos.service.ts
+++ b/apps/api/src/tickets/votos.service.ts
@@ -1,8 +1,9 @@
 import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { canResidenteSeeTicket } from '@consorciofix/domain';
-import { ticket, unidad, vinculoResidente, voto } from '../db/schema/index.js';
+import { ticket, voto } from '../db/schema/index.js';
 import { withTenant } from '../db/client.js';
+import { loadResidenteCtx } from '../common/residente-ctx.js';
 
 @Injectable()
 export class VotosService {
@@ -17,33 +18,21 @@ export class VotosService {
       )[0];
       if (!t) throw new NotFoundException('ticket not found');
 
-      // Vínculos activos del residente.
-      const vinculos = await tx
-        .select()
-        .from(vinculoResidente)
-        .where(
-          and(
-            eq(vinculoResidente.tenantId, tenantId),
-            eq(vinculoResidente.residenteId, residenteId),
-            eq(vinculoResidente.activo, true),
-          ),
-        );
-      const unidadIds = new Set(vinculos.map((v) => v.unidadId));
-
-      // Consorcios donde el residente tiene vínculo (vía sus unidades).
-      let consorcioIds = new Set<string>();
-      if (unidadIds.size > 0) {
-        const unidades = await tx
-          .select({ consorcioId: unidad.consorcioId })
-          .from(unidad)
-          .where(inArray(unidad.id, Array.from(unidadIds)));
-        consorcioIds = new Set(unidades.map((u) => u.consorcioId));
+      // Las conductas no se votan (RF-F02 / P5): son una denuncia entre
+      // vecinos, no un reclamo colectivo que gane prioridad por apoyo. Sin
+      // este chequeo el propio denunciado podía votar la denuncia hecha en su
+      // contra —y de paso quedaba suscripto a sus notificaciones—.
+      if (t.tipo === 'CONDUCTA') {
+        throw new ForbiddenException('los tickets de conducta no se votan');
       }
 
-      const can = canResidenteSeeTicket(
-        { residenteId, consorcioIds, unidadIds },
-        { tipo: t.tipo, origen: t.origen, unidadId: t.unidadId, consorcioId: t.consorcioId },
-      );
+      const ctx = await loadResidenteCtx(tx, tenantId, residenteId);
+      const can = canResidenteSeeTicket(ctx, {
+        tipo: t.tipo,
+        origen: t.origen,
+        unidadId: t.unidadId,
+        consorcioId: t.consorcioId,
+      });
       if (!can) throw new ForbiddenException('ticket no visible para votar');
 
       // Idempotente vía UNIQUE(ticket_id, residente_id).

--- a/apps/api/src/webhooks/whatsapp.controller.ts
+++ b/apps/api/src/webhooks/whatsapp.controller.ts
@@ -60,15 +60,29 @@ export class WhatsAppWebhookController {
     const raw = req.rawBody;
     if (!raw || raw.length === 0) throw new BadRequestException('missing body');
 
-    if (secret && !verifyMetaSignature(raw, signature, secret)) {
+    // Fail-closed. Antes la verificación se salteaba cuando el secreto estaba
+    // vacío (`if (secret && !verify)`), así que un deploy sin la variable
+    // aceptaba cualquier payload en silencio: cualquiera podía crear tickets
+    // a nombre de residentes reales. Ahora la falta de secreto es un error.
+    if (!secret) {
+      this.log.error('WHATSAPP_APP_SECRET no configurado: se rechaza el webhook');
+      throw new UnauthorizedException('webhook signature not configured');
+    }
+    if (!verifyMetaSignature(raw, signature, secret)) {
       throw new UnauthorizedException('invalid signature');
     }
 
     const inbound = this.provider.parseWebhook(req.body);
     if (inbound.length === 0) return { status: 'ok', kind: 'non-message' };
 
+    // Idempotencia real (regla 3). El UNIQUE(provider, wamid) ya evitaba la
+    // fila duplicada, pero el encolado corría igual: una reentrega de Meta
+    // —que ocurre ante cualquier timeout o 5xx— se procesaba de nuevo y
+    // corrompía la sesión del bot, interpretándose como respuesta del usuario.
+    // Ahora solo seguimos con los mensajes que realmente insertamos.
+    const nuevos: typeof inbound = [];
     for (const m of inbound) {
-      await systemDb
+      const ins = await systemDb
         .insert(webhookEvent)
         .values({
           provider: 'whatsapp',
@@ -77,10 +91,13 @@ export class WhatsAppWebhookController {
           payload: m,
           estado: 'RECIBIDO',
         })
-        .onConflictDoNothing({ target: [webhookEvent.provider, webhookEvent.wamid] });
+        .onConflictDoNothing({ target: [webhookEvent.provider, webhookEvent.wamid] })
+        .returning({ wamid: webhookEvent.wamid });
+      if (ins.length > 0) nuevos.push(m);
+      else this.log.log({ wamid: m.wamid }, 'reentrega ignorada (wamid ya recibido)');
     }
 
-    for (const m of inbound) {
+    for (const m of nuevos) {
       if (this.fallback) {
         setImmediate(() => {
           this.bot.handle(m).catch((err) => {
@@ -109,6 +126,6 @@ export class WhatsAppWebhookController {
       }
     }
 
-    return { status: 'ok', received: inbound.length };
+    return { status: 'ok', received: inbound.length, procesados: nuevos.length };
   }
 }

--- a/apps/api/test/integration/seguridad-endpoints.test.ts
+++ b/apps/api/test/integration/seguridad-endpoints.test.ts
@@ -1,0 +1,312 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import { json } from 'express';
+import type { INestApplication } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { AppModule } from '../../src/app.module.js';
+import { systemDb } from '../../src/db/client.js';
+import {
+  consorcio,
+  gasto,
+  residente,
+  tenant as tenantTable,
+  ticket,
+  unidad,
+  vinculoResidente,
+} from '../../src/db/schema/index.js';
+
+/**
+ * Suite de seguridad row-level, **vía HTTP**.
+ *
+ * Los tests de fase5 llaman a los services directamente (`new MeService()`),
+ * así que ningún guard de Nest se ejercita: por eso pasaban en verde mientras
+ * tres endpoints devolvían datos privados a cualquier autenticado. Estos
+ * tests levantan la app completa y pegan por HTTP, que es el único modo de
+ * cubrir la cadena guard → controller → policy.
+ *
+ * Cada caso corresponde a un agujero reproducido en la auditoría del
+ * 2026-08-17 contra el entorno local.
+ */
+const PREFIX = `sec_${Date.now()}_`;
+
+let app: INestApplication;
+let base: string;
+
+let ten: { id: string };
+let consA: { id: string }; // consorcio del residente
+let consB: { id: string }; // consorcio ajeno
+let uniA: { id: string };
+let uniB: { id: string }; // unidad del consorcio ajeno
+let ocupante: { id: string }; // vive en uniA
+let denunciante: { id: string }; // vive en uniA y denuncia
+let ticketConducta: { id: string };
+let ticketAjeno: { id: string };
+let ticketComun: { id: string };
+
+// El login está rate-limited (y está bien que lo esté), así que se hace una
+// sola vez en beforeAll y los tests reusan el token.
+let tokenOcupante: string;
+let refreshOcupante: string;
+
+async function login(email: string): Promise<{ accessToken: string; refreshToken: string }> {
+  const res = await fetch(`${base}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'test1234' }),
+  });
+  const body = (await res.json()) as { accessToken?: string; refreshToken?: string };
+  if (!body.accessToken || !body.refreshToken) {
+    throw new Error(`login falló para ${email}: ${JSON.stringify(body)}`);
+  }
+  return { accessToken: body.accessToken, refreshToken: body.refreshToken };
+}
+
+function auth(token: string): Record<string, string> {
+  return { authorization: `Bearer ${token}` };
+}
+
+// Hash Argon2id de 'test1234', para no depender del seed.
+let passwordHash: string;
+
+beforeAll(async () => {
+  const { PasswordService } = await import('../../src/auth/password.service.js');
+  passwordHash = await new PasswordService().hash('test1234');
+
+  ten = (await systemDb.insert(tenantTable).values({ nombre: `${PREFIX}t`, plan: 'basico' }).returning())[0]!;
+  consA = (await systemDb.insert(consorcio).values({ tenantId: ten.id, nombre: `${PREFIX}A`, tipo: 'EDIFICIO' }).returning())[0]!;
+  consB = (await systemDb.insert(consorcio).values({ tenantId: ten.id, nombre: `${PREFIX}B`, tipo: 'EDIFICIO' }).returning())[0]!;
+  uniA = (await systemDb.insert(unidad).values({ tenantId: ten.id, consorcioId: consA.id, etiqueta: '4A' }).returning())[0]!;
+  uniB = (await systemDb.insert(unidad).values({ tenantId: ten.id, consorcioId: consB.id, etiqueta: '9Z' }).returning())[0]!;
+
+  const mk = async (slug: string) =>
+    (
+      await systemDb
+        .insert(residente)
+        .values({
+          tenantId: ten.id,
+          nombre: `${PREFIX}${slug}`,
+          email: `${PREFIX}${slug}@test.dev`,
+          passwordHash,
+          telefonoE164: `+549${String(Date.now()).slice(-9)}${slug.length}`,
+        })
+        .returning()
+    )[0]!;
+
+  ocupante = await mk('ocupante');
+  denunciante = await mk('denunciante');
+
+  for (const r of [ocupante, denunciante]) {
+    await systemDb.insert(vinculoResidente).values({
+      tenantId: ten.id,
+      residenteId: r.id,
+      unidadId: uniA.id,
+      rol: 'PROPIETARIO',
+      activo: true,
+    });
+  }
+
+  // Conducta contra la unidad del ocupante, reportada por el denunciante.
+  // El ocupante DEBE ver el ticket, pero nunca al denunciante (RF-F02).
+  ticketConducta = (
+    await systemDb
+      .insert(ticket)
+      .values({
+        tenantId: ten.id,
+        consorcioId: consA.id,
+        unidadId: uniA.id,
+        reportanteId: denunciante.id,
+        tipo: 'CONDUCTA',
+        origen: 'UNIDAD',
+        urgencia: 'MEDIA',
+        estado: 'VALIDADO',
+        titulo: `${PREFIX}ruidos`,
+        descripcionNormalizada: 'ruidos molestos',
+      })
+      .returning()
+  )[0]!;
+
+  // Ticket de un consorcio donde el residente NO tiene vínculo.
+  ticketAjeno = (
+    await systemDb
+      .insert(ticket)
+      .values({
+        tenantId: ten.id,
+        consorcioId: consB.id,
+        unidadId: uniB.id,
+        tipo: 'INFRAESTRUCTURA',
+        origen: 'UNIDAD',
+        urgencia: 'ALTA',
+        estado: 'VALIDADO',
+        titulo: `${PREFIX}ajeno`,
+        descripcionNormalizada: 'no debe verse',
+      })
+      .returning()
+  )[0]!;
+  await systemDb.insert(gasto).values({
+    tenantId: ten.id,
+    ticketId: ticketAjeno.id,
+    descripcion: 'presupuesto tentativo',
+    monto: '999999',
+    moneda: 'ARS',
+    estado: 'BORRADOR',
+    comprobanteUrl: 'https://privado/comprobante.pdf',
+  });
+
+  // Espacio común del consorcio del residente, con un confirmado y un borrador.
+  ticketComun = (
+    await systemDb
+      .insert(ticket)
+      .values({
+        tenantId: ten.id,
+        consorcioId: consA.id,
+        unidadId: null,
+        tipo: 'INFRAESTRUCTURA',
+        origen: 'ESPACIO_COMUN',
+        urgencia: 'ALTA',
+        estado: 'SOLUCIONADO',
+        titulo: `${PREFIX}comun`,
+        descripcionNormalizada: 'caño del palier',
+      })
+      .returning()
+  )[0]!;
+  await systemDb.insert(gasto).values([
+    { tenantId: ten.id, ticketId: ticketComun.id, descripcion: 'arreglo', monto: '50000', moneda: 'ARS', estado: 'CONFIRMADO' },
+    { tenantId: ten.id, ticketId: ticketComun.id, descripcion: 'tentativo', monto: '777777', moneda: 'ARS', estado: 'BORRADOR' },
+  ]);
+
+  app = await NestFactory.create(AppModule, { logger: false });
+  app.use(json({ verify: (req, _res, buf) => { (req as unknown as { rawBody?: Buffer }).rawBody = buf; } }));
+  await app.listen(0);
+  base = await app.getUrl().then((u) => u.replace('[::1]', '127.0.0.1'));
+
+  const sesion = await login(`${PREFIX}ocupante@test.dev`);
+  tokenOcupante = sesion.accessToken;
+  refreshOcupante = sesion.refreshToken;
+}, 60_000);
+
+afterAll(async () => {
+  await app?.close();
+  await systemDb.delete(tenantTable).where(eq(tenantTable.id, ten.id)); // cascade
+});
+
+describe('GET /tickets/:id — visibilidad row-level (RF-F02, RF-H03)', () => {
+  it('no revela la identidad del denunciante al ocupante acusado', async () => {
+    const res = await fetch(`${base}/tickets/${ticketConducta.id}`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(200);
+    const t = (await res.json()) as { reportanteId: string | null; titulo: string };
+    // Ve el ticket (es ocupante de la unidad reportada)...
+    expect(t.titulo).toContain('ruidos');
+    // ...pero jamás quién lo reportó.
+    expect(t.reportanteId).toBeNull();
+  });
+
+  it('no deja leer un ticket de un consorcio donde no tiene vínculo', async () => {
+    const res = await fetch(`${base}/tickets/${ticketAjeno.id}`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(404);
+  });
+
+  it('rechaza sin token', async () => {
+    const res = await fetch(`${base}/tickets/${ticketComun.id}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /tickets/:id/gastos — G10 y borradores', () => {
+  it('no expone gastos de un ticket de otro consorcio', async () => {
+    const res = await fetch(`${base}/tickets/${ticketAjeno.id}/gastos`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(404);
+  });
+
+  it('en un espacio común muestra solo CONFIRMADO, nunca el borrador', async () => {
+    const res = await fetch(`${base}/tickets/${ticketComun.id}/gastos`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as Array<{ estado: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows.every((g) => g.estado === 'CONFIRMADO')).toBe(true);
+  });
+
+  it('no expone el costo de un ticket de CONDUCTA aunque el ticket sea visible', async () => {
+    const res = await fetch(`${base}/tickets/${ticketConducta.id}/gastos`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(404);
+  });
+
+  it('el total de un ticket ajeno tampoco se filtra', async () => {
+    const res = await fetch(`${base}/tickets/${ticketAjeno.id}/gastos/total`, { headers: auth(tokenOcupante) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /tickets/:id/votes — las conductas no se votan', () => {
+  it('el acusado no puede votar la denuncia hecha en su contra', async () => {
+    const res = await fetch(`${base}/tickets/${ticketConducta.id}/votes`, {
+      method: 'POST',
+      headers: { ...auth(tokenOcupante), 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('un ticket de espacio común sí se vota', async () => {
+    const res = await fetch(`${base}/tickets/${ticketComun.id}/votes`, {
+      method: 'POST',
+      headers: { ...auth(tokenOcupante), 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('POST /tickets — pertenencia al consorcio (RF-H03)', () => {
+  it('no permite crear un ticket en un consorcio ajeno', async () => {
+    const res = await fetch(`${base}/tickets`, {
+      method: 'POST',
+      headers: { ...auth(tokenOcupante), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        consorcio_id: consB.id,
+        tipo: 'INFRAESTRUCTURA',
+        titulo: 'intento en consorcio ajeno',
+        descripcion: 'no debería entrar',
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('rechaza una unidad que no pertenece al consorcio indicado', async () => {
+    const res = await fetch(`${base}/tickets`, {
+      method: 'POST',
+      headers: { ...auth(tokenOcupante), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        consorcio_id: consA.id,
+        unidad_id: uniB.id,
+        tipo: 'CONDUCTA',
+        titulo: 'unidad cruzada',
+        descripcion: 'no debería entrar',
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('permite crear en el propio consorcio', async () => {
+    const res = await fetch(`${base}/tickets`, {
+      method: 'POST',
+      headers: { ...auth(tokenOcupante), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        consorcio_id: consA.id,
+        unidad_id: uniA.id,
+        tipo: 'INFRAESTRUCTURA',
+        titulo: 'reporte legítimo',
+        descripcion: 'pérdida de agua',
+      }),
+    });
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('Tokens — un refresh no sirve como access (RF-H04)', () => {
+  it('rechaza el refresh token en el header de autorización', async () => {
+    expect(refreshOcupante).toBeTruthy();
+    const abuso = await fetch(`${base}/tickets/${ticketComun.id}`, { headers: auth(refreshOcupante) });
+    expect(abuso.status).toBe(401);
+  });
+});

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,14 +1,32 @@
 import { defineConfig } from 'vitest/config';
+import swc from 'unplugin-swc';
 
 // Tests de integración: ejercitan servicios/controllers contra la DB real
 // (postgres up + migraciones aplicadas), igual que la suite de isolation.
 // Crean su propia data con prefijo único y limpian por cascade.
 // Requiere DATABASE_URL (rol app, RLS aplica) y DATABASE_OWNER_URL.
+//
+// El transform es SWC y no el esbuild por defecto de vitest: esbuild NO emite
+// metadata de decoradores, así que la inyección de dependencias de NestJS
+// queda rota y los guards se instancian sin sus dependencias. Ese era el
+// motivo por el que los tests previos llamaban a los servicios a mano
+// (`new MeService()`) en vez de pegarle por HTTP — y por el que ningún guard
+// estaba cubierto mientras tres endpoints filtraban datos privados.
 export default defineConfig({
+  plugins: [
+    swc.vite({
+      module: { type: 'es6' },
+      jsc: {
+        target: 'es2022',
+        parser: { syntax: 'typescript', decorators: true },
+        transform: { legacyDecorator: true, decoratorMetadata: true },
+      },
+    }),
+  ],
   test: {
     include: ['test/integration/**/*.test.ts'],
     testTimeout: 30000,
-    hookTimeout: 30000,
+    hookTimeout: 60000,
     pool: 'forks',
     poolOptions: {
       forks: { singleFork: true }, // misma DB = no paralelizar

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,10 +135,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.5
-        version: 10.4.9(esbuild@0.19.12)
+        version: 10.4.9(@swc/core@1.16.0)(esbuild@0.19.12)
       '@nestjs/testing':
         specifier: ^10.4.0
         version: 10.4.22(@nestjs/common@10.4.22(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
+      '@swc/core':
+        specifier: ^1.16.0
+        version: 1.16.0
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -159,10 +162,13 @@ importers:
         version: 10.28.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.43)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.16.0)(@types/node@20.19.43)(typescript@5.9.3)
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.11
+        version: 1.5.11(@swc/core@1.16.0)(esbuild@0.19.12)(rollup@4.61.1)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12))
       vitest:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.43)(terser@5.48.0)
@@ -1072,11 +1078,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1682,7 +1688,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -2305,6 +2311,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
@@ -2450,6 +2465,93 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@swc/core-darwin-arm64@1.16.0':
+    resolution: {integrity: sha512-SJQPl+xG/zB8bNjC/gTg3WOmOvz7EzlQD+VShfCKFYPNr2qvb+vATUY11vYEjnMWCn6wV8H8eAtjQrVflYyX5A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.16.0':
+    resolution: {integrity: sha512-ql2JVch8V5t1i+HxiiuD4oVDI1dOku4/e3QiCkplONrm3SLitqNAP+nztHN51fSG2IgGuOwpAi3hgA+ukT5yQg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.16.0':
+    resolution: {integrity: sha512-PcdDBaRbe39y37h1rXVkhNy7mEU7f8b34KD761C68R23EsfMsj5oDPVddRzGdSRAvwwSfH0WSNEHgYmc/AJipg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.16.0':
+    resolution: {integrity: sha512-t21IUztHQ/COucy7Kk9eIlehmq08H/hYq7aRA6fZox3S5ddi6TxWPK6e5S/+aTCf6+Od9qQ+LIpjHMiTy737vA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.16.0':
+    resolution: {integrity: sha512-d9+iajbMB87b0umgbP+Gy3yBDSDgty4Q6H5pZ8fgTb/dOoKIwwynP4L4kvWCOFg2i49kxmAAUs1uJZh9s0E+RQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-ppc64-gnu@1.16.0':
+    resolution: {integrity: sha512-QRpeKGOg+B0qmo3BFU+6rL/gpoKYYJ7OFSMf5DNMafohYZ/iq2qvAH9Gcrf8NxROj3iooKOVewJ+YgahH1nSLw==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@swc/core-linux-s390x-gnu@1.16.0':
+    resolution: {integrity: sha512-q+Vr/hmHCcRXT/WFzOJC+T6GGEEtq2iaTtmyLfxO7yzu4ckgcqSNkg9m181wfNhuMwfNBoBhOfwQCnLsGZ5F4g==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.16.0':
+    resolution: {integrity: sha512-DWVBc3QnpsSgKoq8N4rmZeZa5r/XrHdLkITsExN/tvTdqPtAPDPt+Ysy33OfgBlyN8lNe4xwsXWe6DXlRkJeRQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.16.0':
+    resolution: {integrity: sha512-6XCgDSc1HPf/5dpjvABhKHICiBcsuZyW3hQMkn8sxel0TqprkJGp+H4iaBYIUTPixhrBub2hBPtfjcZLE6yL3w==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.16.0':
+    resolution: {integrity: sha512-T/+9VVCZJ3AKEth9IP3U9AJ2YscQq+7LUqRTvfR4a2q36+Ri22oOwUizpAKOqQ42vb2Y/kOa4TOcJOfHoDIT/w==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.16.0':
+    resolution: {integrity: sha512-Pr1lsR/PMs8ndL0UWMrW8nLZ7H7sspIxBRDdjL8f+YJ/FJNASgzfunbVVXAqj0csgIJYHPZy+OW9smjFmk1Rcg==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.16.0':
+    resolution: {integrity: sha512-ktdeYLgOQdaonvsj5tJijqgpb0wk7gfF80wCFVA0kucI1hhSUIyfcGbjo5+9sdqv38OhMnTdLoA6xbqgOgPQjw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.16.0':
+    resolution: {integrity: sha512-zSdvEHxBg00WhUNtW/u58hhcdR33gjtMQvOBo8F7POWJDyjRCt/miKfhidT3hCc/118RUwNnlEAmxiihFMbK4Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.28':
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -2803,6 +2905,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3544,6 +3647,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -4001,6 +4105,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -5046,6 +5153,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
@@ -6968,6 +7079,44 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.11:
+    resolution: {integrity: sha512-R7U4GbfrESPnYLn3nXREZrwhKQk3BAmTBoKJ5lmo7btTc/yJpNsDzavBWo+XpQTjDSIogiZEAxC5ig/vfMWxWg==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '*'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -7125,6 +7274,9 @@ packages:
   webpack-sources@3.5.0:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   webpack@5.97.1:
     resolution: {integrity: sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==}
@@ -9098,7 +9250,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@nestjs/cli@10.4.9(esbuild@0.19.12)':
+  '@nestjs/cli@10.4.9(@swc/core@1.16.0)(esbuild@0.19.12)':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
       '@angular-devkit/schematics': 17.3.11(chokidar@3.6.0)
@@ -9108,7 +9260,7 @@ snapshots:
       chokidar: 3.6.0
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(esbuild@0.19.12))
+      fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12))
       glob: 10.4.5
       inquirer: 8.2.6
       node-emoji: 1.11.0
@@ -9117,8 +9269,10 @@ snapshots:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.7.2
-      webpack: 5.97.1(esbuild@0.19.12)
+      webpack: 5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)
       webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/core': 1.16.0
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -9779,6 +9933,14 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rollup/pluginutils@5.4.0(rollup@4.61.1)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.61.1
+
   '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
@@ -9876,6 +10038,66 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@swc/core-darwin-arm64@1.16.0':
+    optional: true
+
+  '@swc/core-darwin-x64@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.16.0':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.16.0':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.16.0':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.16.0':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.16.0':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.16.0':
+    optional: true
+
+  '@swc/core@1.16.0':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.0
+      '@swc/core-darwin-x64': 1.16.0
+      '@swc/core-linux-arm-gnueabihf': 1.16.0
+      '@swc/core-linux-arm64-gnu': 1.16.0
+      '@swc/core-linux-arm64-musl': 1.16.0
+      '@swc/core-linux-ppc64-gnu': 1.16.0
+      '@swc/core-linux-s390x-gnu': 1.16.0
+      '@swc/core-linux-x64-gnu': 1.16.0
+      '@swc/core-linux-x64-musl': 1.16.0
+      '@swc/core-win32-arm64-msvc': 1.16.0
+      '@swc/core-win32-ia32-msvc': 1.16.0
+      '@swc/core-win32-x64-msvc': 1.16.0
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.28':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -11649,6 +11871,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -12061,7 +12285,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(esbuild@0.19.12)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -12076,7 +12300,7 @@ snapshots:
       semver: 7.8.4
       tapable: 2.3.3
       typescript: 5.7.2
-      webpack: 5.97.1(esbuild@0.19.12)
+      webpack: 5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)
 
   form-data@3.0.4:
     dependencies:
@@ -12920,6 +13144,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.19.0
 
   lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.2: {}
 
@@ -14735,14 +14961,15 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.6.1(esbuild@0.19.12)(webpack@5.97.1(esbuild@0.19.12)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.16.0)(esbuild@0.19.12)(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.97.1(esbuild@0.19.12)
+      webpack: 5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)
     optionalDependencies:
+      '@swc/core': 1.16.0
       esbuild: 0.19.12
 
   terser@5.48.0:
@@ -14863,7 +15090,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.16.0)(@types/node@20.19.43)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -14880,6 +15107,8 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.16.0
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -15061,6 +15290,34 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.11(@swc/core@1.16.0)(esbuild@0.19.12)(rollup@4.61.1)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      '@swc/core': 1.16.0
+      load-tsconfig: 0.2.5
+      unplugin: 3.3.0(esbuild@0.19.12)(rollup@4.61.1)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  unplugin@3.3.0(esbuild@0.19.12)(rollup@4.61.1)(vite@5.4.21(@types/node@20.19.43)(terser@5.48.0))(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.19.12
+      rollup: 4.61.1
+      vite: 5.4.21(@types/node@20.19.43)(terser@5.48.0)
+      webpack: 5.97.1(@swc/core@1.16.0)(esbuild@0.19.12)
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -15202,7 +15459,9 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.97.1(esbuild@0.19.12):
+  webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
@@ -15224,7 +15483,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.19.12)(webpack@5.97.1(esbuild@0.19.12))
+      terser-webpack-plugin: 5.6.1(@swc/core@1.16.0)(esbuild@0.19.12)(webpack@5.97.1(@swc/core@1.16.0)(esbuild@0.19.12))
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
# Seguridad — aplicar las policies de dominio donde no se invocaban

**RF / Gap:** RF-F02, RF-H03, RF-H04, G10, reglas 1 y 3 de CLAUDE.md

Tres handlers HTTP devolvían datos privados a cualquier autenticado. Las reglas de `packages/domain` estaban bien escritas y con 100 % de cobertura; simplemente **no se invocaban**, y `RolesGuard` deja pasar a cualquier autenticado cuando el handler no declara `@Roles`.

## Reproducido antes del arreglo, contra el entorno local

| Prueba | Antes | Ahora |
|---|---|---|
| `GET /tickets/:id` de una CONDUCTA, como el ocupante acusado | `200` + `reportanteId` del denunciante | `200` con `reportanteId: null` |
| `GET /tickets/:id` de un consorcio ajeno | `200` + lee el ticket | `404` |
| `GET /tickets/:id/gastos` de un ticket ajeno | `200` + `BORRADOR` + URL del comprobante | `404` |
| `POST /tickets/:id/votes` sobre la denuncia propia | `201` | `403` |
| Refresh token en el header de autorización | `200` | `401` |
| `POST /tickets` en consorcio ajeno | crea el ticket | `403` |

El leak de conducta es el más grave: rompe RF-F02, que es la promesa central del módulo, y es el camino que usa la app móvil — la pantalla no lo pinta, pero el UUID del denunciante viaja al dispositivo del denunciado.

## Cambios

- `GET /tickets/:id`, `GET /tickets/:id/gastos` y `/gastos/total`: `@Roles` explícito + policy de dominio. Para residentes se proyecta el ticket ocultando el reportante en conducta y se fuerza `estado = CONFIRMADO` en gastos. Se responde **404 y no 403** cuando el recurso existe pero no es visible: un 403 confirmaría su existencia.
- `votos.service`: las conductas no se votan (RF-F02 / P5).
- `POST /tickets`: valida pertenencia al consorcio y que la unidad pertenezca a él. No exige ser ocupante de la unidad, porque en conducta es justamente la del vecino denunciado.
- `verifyAccess` rechaza `typ: 'refresh'`. Ambos tokens se firman con el mismo secreto, así que el de 7 días servía como bearer de acceso.
- Webhook de WhatsApp **fail-closed**: con `WHATSAPP_APP_SECRET` vacío se salteaba la verificación de firma en silencio.
- **Idempotencia real (regla 3):** el `enqueue` se condiciona al resultado del insert. El `UNIQUE(provider, wamid)` evitaba la fila duplicada pero el mensaje se procesaba igual; reproducido en vivo, una reentrega de Meta corrompía la sesión del bot al interpretarse como respuesta del usuario.

## Por qué esto no lo detectó ningún test

Los tests existentes llaman a los servicios directamente (`new MeService()`), así que **ningún guard de Nest se ejercita**: los 7 de fase5 pasaban en verde con los tres leaks abiertos. La causa de fondo es que vitest transpila con esbuild, que no emite metadata de decoradores y rompe la inyección de dependencias de NestJS.

Se configura SWC en el vitest de integración y se agregan **13 tests que pegan por HTTP** contra la app real, uno por agujero. Ahora la cadena guard → controller → policy sí está cubierta.

## Definition of Done

- [x] Criterios de aceptación cumplidos
- [x] Tests pasando: 20/20 integración, 12/12 isolation, unitarios verdes
- [x] `pnpm lint` y `pnpm typecheck` verdes
- [x] Suite de aislamiento verde (se tocó visibilidad row-level)
- [x] Verificación manual contra la API en vivo: 17 casos, incluyendo los caminos legítimos para descartar regresiones
- [ ] `pnpm ai:eval` — N/A, no se tocó ningún prompt

## Queda pendiente, del mismo tipo

`findResidente` (`bot.service.ts:307-314`) busca por teléfono **sin filtrar por tenant**, con `limit(1)`, mientras la constraint es `(tenant_id, telefono_e164)`. Usa `systemDb`, así que RLS no lo cubre. Es la regla 1 y va en un PR aparte.
