### PR TITLE
fix: probar la lógica de la app en runtime y cerrar lo que quedaba a medio funcionar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,11 @@ NODE_ENV=development
 LOG_LEVEL=info
 
 # --- API ---
-API_PORT=3000
+API_PORT=3003
 # Puerto del panel web. Si cambiás API_PORT, el proxy del panel lo sigue solo.
 ADMIN_WEB_PORT=5173
 API_HOST=0.0.0.0
-API_URL=http://localhost:3000
+API_URL=http://localhost:3003
 # Limite del body. El global va bajo a proposito: es superficie sin autenticar.
 # El de /import es alto porque una planilla de residentes lo necesita (RF-A05).
 API_BODY_LIMIT=256kb
@@ -86,11 +86,7 @@ VOYAGE_API_KEY=
 SENTRY_DSN=
 
 # --- Mobile (Expo) ---
-EXPO_PUBLIC_API_URL=http://localhost:3000
-# Limite del body. El global va bajo a proposito: es superficie sin autenticar.
-# El de /import es alto porque una planilla de residentes lo necesita (RF-A05).
-API_BODY_LIMIT=256kb
-API_IMPORT_BODY_LIMIT=4mb
+EXPO_PUBLIC_API_URL=http://localhost:3003
 
 # --- Telegram (canal alternativo a WhatsApp) ---
 # Crear el bot con @BotFather y registrar el webhook con setWebhook pasando

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ LOG_LEVEL=info
 
 # --- API ---
 API_PORT=3000
+# Puerto del panel web. Si cambiás API_PORT, el proxy del panel lo sigue solo.
+ADMIN_WEB_PORT=5173
 API_HOST=0.0.0.0
 API_URL=http://localhost:3000
 # Limite del body. El global va bajo a proposito: es superficie sin autenticar.

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,11 @@ build/
 *.tsbuildinfo
 
 # Env
-.env
-.env.local
-.env.*.local
+# Cualquier variante del .env, no solo las que uno se acuerda de listar.
+# Antes esto era `.env` + `.env.local` + `.env.*.local`, así que un `.env.bak`
+# —lo primero que uno crea antes de editar a mano— quedaba fuera y las
+# credenciales terminaban listas para commitear.
+.env*
 !.env.example
 
 # Logs

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { Shell } from './components/Shell.js';
 import { AuthProvider, useAuth } from './lib/auth-ctx.js';
 import { AuditPage } from './pages/AuditPage.js';
+import { AdministracionesPage } from './pages/AdministracionesPage.js';
 import { BandejaPage } from './pages/BandejaPage.js';
 import { ConsorciosPage } from './pages/ConsorciosPage.js';
 import { LoginPage } from './pages/LoginPage.js';
@@ -39,6 +40,7 @@ export function App(): JSX.Element {
           <Route path="residentes" element={<ResidentesPage />} />
           <Route path="notificaciones" element={<NotificationsPage />} />
           <Route path="bitacora" element={<AuditPage />} />
+          <Route path="administraciones" element={<AdministracionesPage />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -117,9 +117,19 @@ export function Shell(_props: ShellProps): JSX.Element {
   const nombreTenant = tenants.find((t) => t.id === tenantElegido)?.nombre;
   // El selector de arriba muestra administraciones al super admin y consorcios
   // al resto: es el mismo lugar, pero el contexto que cada uno cambia es otro.
+  // Para el admin este control NO es un selector de contexto: no existe un
+  // "consorcio activo" global, cada pantalla tiene su propio filtro. Mostraba
+  // `consorcios[0].nombre`, o sea el primero de la lista, y con dos consorcios
+  // decía uno mientras la pantalla trabajaba con el otro. Se muestra el nombre
+  // solo cuando hay uno —ahí no hay ambigüedad posible— y si hay varios se dice
+  // lo que el control realmente es.
   const tituloSwitcher = esSuper
     ? (nombreTenant ?? 'Elegí administración')
-    : (consorcios[0]?.nombre ?? 'Sin consorcios');
+    : totalConsorcios === 0
+      ? 'Sin consorcios'
+      : totalConsorcios === 1
+        ? consorcios[0]!.nombre
+        : 'Mis consorcios';
   const subtituloSwitcher = esSuper
     ? (tenantElegido ? 'administración activa' : 'ninguna elegida')
     : totalConsorcios === 0
@@ -178,6 +188,14 @@ export function Shell(_props: ShellProps): JSX.Element {
                 padding: 6, zIndex: 20, maxHeight: 260, overflowY: 'auto',
               }}
             >
+              {!esSuper && (
+                <div
+                  className="uppercase"
+                  style={{ padding: '4px 8px 6px', color: 'var(--cf-ink-3)', fontSize: 10.5 }}
+                >
+                  Ir a las unidades de
+                </div>
+              )}
               {esSuper
                 ? tenants.map((t) => (
                     <button

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -112,7 +112,7 @@ export function Shell(_props: ShellProps): JSX.Element {
   // El selector de arriba muestra administraciones al super admin y consorcios
   // al resto: es el mismo lugar, pero el contexto que cada uno cambia es otro.
   const tituloSwitcher = esSuper
-    ? (nombreTenant ?? 'Elegí una administración')
+    ? (nombreTenant ?? 'Elegí administración')
     : (consorcios[0]?.nombre ?? 'Sin consorcios');
   const subtituloSwitcher = esSuper
     ? (tenantElegido ? 'administración activa' : 'ninguna elegida')
@@ -143,7 +143,12 @@ export function Shell(_props: ShellProps): JSX.Element {
           <button
             type="button"
             className="sidebar-tenant"
-            style={{ width: '100%', cursor: 'pointer', font: 'inherit', textAlign: 'left' }}
+            /* Sin `width: 100%`: la clase ya tiene `margin: 0 14px` y es
+               `display: flex`, así que ocupa el ancho disponible descontando sus
+               márgenes. Con el 100% medía 232px + 28px de margen y se desbordaba
+               del sidebar exactamente esos 28px. */
+            style={{ cursor: 'pointer', font: 'inherit', textAlign: 'left' }}
+            title={esSuper && !tenantElegido ? 'Elegí una administración para trabajar' : tituloSwitcher}
             onClick={() => setSwitcherOpen((o) => !o)}
             disabled={esSuper ? tenants.length === 0 : totalConsorcios === 0}
           >

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -25,6 +25,15 @@ const NAV: NavItem[] = [
   { to: '/bitacora', label: 'Bitácora', icon: Icons.shield },
 ];
 
+/**
+ * Solo para el super administrador de la plataforma: da de alta administraciones
+ * (RF-A01). No se muestra al ADMIN porque la API le responde 403, y ofrecerle un
+ * link que siempre falla es peor que no ofrecerlo.
+ */
+const NAV_SUPER: NavItem[] = [
+  { to: '/administraciones', label: 'Administraciones', icon: Icons.building },
+];
+
 export function Shell(_props: ShellProps): JSX.Element {
   const { user, logout } = useAuth();
   const nav = useNavigate();
@@ -122,7 +131,7 @@ export function Shell(_props: ShellProps): JSX.Element {
         </div>
 
         <nav className="sidebar-nav">
-          {NAV.map(({ to, label, icon: Icon, end }) => (
+          {[...NAV, ...(user?.kind === 'SUPER_ADMIN' ? NAV_SUPER : [])].map(({ to, label, icon: Icon, end }) => (
             <NavLink key={to} to={to} end={end ?? false}>
               {({ isActive }) => (
                 <>
@@ -170,14 +179,13 @@ export function Topbar({ title, subtitle, actions }: TopbarProps): JSX.Element {
         <h1>{title}</h1>
         {subtitle && <div className="topbar-sub">{subtitle}</div>}
       </div>
-      <div className="topbar-actions">
-        <div className="search">
-          <Icons.search size={14} />
-          <input placeholder="Buscar incidentes, vecinos…" />
-          <span className="mono" style={{ background: 'var(--cf-bg)', padding: '1px 5px', borderRadius: 4, fontSize: 10.5 }}>⌘K</span>
-        </div>
-        {actions}
-      </div>
+      {/* Acá había un buscador global con un atajo "⌘K" dibujado: el input no
+          tenía value ni onChange y el atajo no existía en ningún listener, así
+          que era el control más visible del panel y no hacía absolutamente
+          nada. La búsqueda real vive en la bandeja, que es donde hay algo que
+          buscar; un buscador global honesto necesitaría un endpoint de búsqueda
+          que la API todavía no tiene. */}
+      <div className="topbar-actions">{actions}</div>
     </div>
   );
 }

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -1,6 +1,13 @@
-import { NavLink, Outlet, useNavigate } from 'react-router-dom';
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { listConsorcios, type Consorcio } from '../lib/api.js';
+import {
+  getTenantOverride,
+  listConsorcios,
+  listTenants,
+  setTenantOverride,
+  type Consorcio,
+  type Tenant,
+} from '../lib/api.js';
 import { useAuth } from '../lib/auth-ctx.js';
 import { Icons } from './Icons.js';
 
@@ -37,13 +44,47 @@ const NAV_SUPER: NavItem[] = [
 export function Shell(_props: ShellProps): JSX.Element {
   const { user, logout } = useAuth();
   const nav = useNavigate();
+  const loc = useLocation();
   const [consorcios, setConsorcios] = useState<Consorcio[]>([]);
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const switcherRef = useRef<HTMLDivElement>(null);
 
+  /**
+   * El SUPER_ADMIN no pertenece a ninguna administración, así que tiene que
+   * elegir en cuál trabajar: la API le exige el header `x-tenant-id` en todo lo
+   * que es de tenant y responde `no tenant in token` sin él.
+   *
+   * `apiFetch` ya mandaba ese header cuando había una administración elegida, y
+   * **ninguna pantalla la dejaba elegir nunca**: la cañería estaba puesta y no
+   * llegaba a ningún lado. El super admin entraba y la bandeja le mostraba el
+   * error crudo de la API.
+   */
+  const esSuper = user?.kind === 'SUPER_ADMIN';
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [tenantElegido, setTenantElegido] = useState<string | null>(getTenantOverride());
+
   useEffect(() => {
+    if (!esSuper) return;
+    listTenants().then(setTenants).catch(() => undefined);
+  }, [esSuper]);
+
+  useEffect(() => {
+    // Sin administración elegida no hay consorcios que pedir: el request
+    // fallaría y ensuciaría la consola con un error esperado.
+    if (esSuper && !tenantElegido) return;
     listConsorcios().then(setConsorcios).catch(() => undefined);
-  }, []);
+  }, [esSuper, tenantElegido]);
+
+  function elegirTenant(id: string) {
+    setTenantOverride(id);
+    setTenantElegido(id);
+    setSwitcherOpen(false);
+    // Recarga completa a propósito: cada pantalla trae sus datos en su propio
+    // `useEffect` y no hay un store global que invalidar. Es un cambio de
+    // contexto poco frecuente, así que la recarga es más confiable que
+    // sincronizar diez pantallas a mano.
+    window.location.reload();
+  }
 
   useEffect(() => {
     if (!switcherOpen) return;
@@ -67,7 +108,20 @@ export function Shell(_props: ShellProps): JSX.Element {
     .toUpperCase();
 
   const totalConsorcios = consorcios.length;
-  const firstName = consorcios[0]?.nombre ?? 'Sin consorcios';
+  const nombreTenant = tenants.find((t) => t.id === tenantElegido)?.nombre;
+  // El selector de arriba muestra administraciones al super admin y consorcios
+  // al resto: es el mismo lugar, pero el contexto que cada uno cambia es otro.
+  const tituloSwitcher = esSuper
+    ? (nombreTenant ?? 'Elegí una administración')
+    : (consorcios[0]?.nombre ?? 'Sin consorcios');
+  const subtituloSwitcher = esSuper
+    ? (tenantElegido ? 'administración activa' : 'ninguna elegida')
+    : totalConsorcios === 0
+      ? 'agregá uno'
+      : totalConsorcios === 1
+        ? '1 consorcio'
+        : `${totalConsorcios} consorcios`;
+  const faltaElegirTenant = esSuper && !tenantElegido && loc.pathname !== '/administraciones';
 
   function onLogout() {
     logout();
@@ -91,18 +145,16 @@ export function Shell(_props: ShellProps): JSX.Element {
             className="sidebar-tenant"
             style={{ width: '100%', cursor: 'pointer', font: 'inherit', textAlign: 'left' }}
             onClick={() => setSwitcherOpen((o) => !o)}
-            disabled={totalConsorcios === 0}
+            disabled={esSuper ? tenants.length === 0 : totalConsorcios === 0}
           >
             <div className="sidebar-tenant-icon">
               <Icons.building size={14} />
             </div>
             <div style={{ flex: 1, minWidth: 0, lineHeight: 1.15 }}>
               <div style={{ fontSize: 12.5, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {firstName}
+                {tituloSwitcher}
               </div>
-              <div style={{ fontSize: 10.5, color: 'var(--cf-ink-3)' }}>
-                {totalConsorcios === 0 ? 'agregá uno' : totalConsorcios === 1 ? '1 consorcio' : `${totalConsorcios} consorcios`}
-              </div>
+              <div style={{ fontSize: 10.5, color: 'var(--cf-ink-3)' }}>{subtituloSwitcher}</div>
             </div>
             <Icons.chevDown size={14} stroke="var(--cf-ink-3)" />
           </button>
@@ -115,17 +167,34 @@ export function Shell(_props: ShellProps): JSX.Element {
                 padding: 6, zIndex: 20, maxHeight: 260, overflowY: 'auto',
               }}
             >
-              {consorcios.map((c) => (
-                <button
-                  key={c.id}
-                  type="button"
-                  className="btn ghost sm"
-                  style={{ width: '100%', justifyContent: 'flex-start', marginBottom: 2 }}
-                  onClick={() => goToConsorcio(c.id)}
-                >
-                  {c.nombre}
-                </button>
-              ))}
+              {esSuper
+                ? tenants.map((t) => (
+                    <button
+                      key={t.id}
+                      type="button"
+                      className="btn ghost sm"
+                      style={{
+                        width: '100%',
+                        justifyContent: 'flex-start',
+                        marginBottom: 2,
+                        fontWeight: t.id === tenantElegido ? 700 : 500,
+                      }}
+                      onClick={() => elegirTenant(t.id)}
+                    >
+                      {t.nombre}
+                    </button>
+                  ))
+                : consorcios.map((c) => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      className="btn ghost sm"
+                      style={{ width: '100%', justifyContent: 'flex-start', marginBottom: 2 }}
+                      onClick={() => goToConsorcio(c.id)}
+                    >
+                      {c.nombre}
+                    </button>
+                  ))}
             </div>
           )}
         </div>
@@ -160,7 +229,47 @@ export function Shell(_props: ShellProps): JSX.Element {
       </aside>
 
       <div className="main">
-        <Outlet />
+        {faltaElegirTenant ? (
+          <>
+            <Topbar
+              title="Elegí una administración"
+              subtitle="Como super admin no perteneces a ninguna: tenés que indicar en cuál trabajar"
+            />
+            <div className="content">
+              <section className="stack">
+                <div className="card">
+                  <p style={{ margin: '0 0 14px', fontSize: 13.5, color: 'var(--cf-ink-2)' }}>
+                    Los consorcios, las unidades y los tickets pertenecen a una administración.
+                    Elegí una acá —o desde el selector de arriba a la izquierda— y el panel entero
+                    va a mostrar sus datos.
+                  </p>
+                  {tenants.length === 0 ? (
+                    <div className="muted small">
+                      Todavía no hay ninguna. Creá la primera en{' '}
+                      <NavLink to="/administraciones">Administraciones</NavLink>.
+                    </div>
+                  ) : (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      {tenants.map((t) => (
+                        <button
+                          key={t.id}
+                          type="button"
+                          className="btn ghost"
+                          style={{ justifyContent: 'flex-start' }}
+                          onClick={() => elegirTenant(t.id)}
+                        >
+                          <Icons.building size={14} /> {t.nombre}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </section>
+            </div>
+          </>
+        ) : (
+          <Outlet />
+        )}
       </div>
     </div>
   );

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
+  EVENTO_CONSORCIOS,
   getTenantOverride,
   listConsorcios,
   listTenants,
@@ -72,7 +73,12 @@ export function Shell(_props: ShellProps): JSX.Element {
     // Sin administración elegida no hay consorcios que pedir: el request
     // fallaría y ensuciaría la consola con un error esperado.
     if (esSuper && !tenantElegido) return;
-    listConsorcios().then(setConsorcios).catch(() => undefined);
+    const cargar = () => listConsorcios().then(setConsorcios).catch(() => undefined);
+    void cargar();
+    // Se recarga cuando alguna pantalla avisa que la lista cambió, así el
+    // selector no queda diciendo "Sin consorcios" después de crear el primero.
+    window.addEventListener(EVENTO_CONSORCIOS, cargar);
+    return () => window.removeEventListener(EVENTO_CONSORCIOS, cargar);
   }, [esSuper, tenantElegido]);
 
   function elegirTenant(id: string) {

--- a/apps/admin-web/src/components/Shell.tsx
+++ b/apps/admin-web/src/components/Shell.tsx
@@ -1,8 +1,12 @@
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import {
+  EVENTO_CONSORCIO_ACTIVO,
   EVENTO_CONSORCIOS,
+  getConsorcioActivo,
   getTenantOverride,
+  limpiarConsorcioActivo,
+  setConsorcioActivo,
   listConsorcios,
   listTenants,
   setTenantOverride,
@@ -81,6 +85,31 @@ export function Shell(_props: ShellProps): JSX.Element {
     return () => window.removeEventListener(EVENTO_CONSORCIOS, cargar);
   }, [esSuper, tenantElegido]);
 
+  /**
+   * Consorcio activo. Lo comparten la Bandeja, el Resumen y Unidades, así que
+   * elegirlo acá filtra el panel entero en vez de navegar a una pantalla.
+   */
+  const [consorcioActivo, setConsorcioActivoState] = useState<string | null>(getConsorcioActivo());
+
+  useEffect(() => {
+    const sincronizar = () => setConsorcioActivoState(getConsorcioActivo());
+    window.addEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+    return () => window.removeEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+  }, []);
+
+  // Si el consorcio guardado ya no está en la lista —lo archivaron, o cambió la
+  // administración— se olvida en vez de dejar al panel filtrando por un id que
+  // no existe y mostrando vacío sin explicación.
+  useEffect(() => {
+    if (!consorcioActivo || consorcios.length === 0) return;
+    if (!consorcios.some((c) => c.id === consorcioActivo)) limpiarConsorcioActivo();
+  }, [consorcioActivo, consorcios]);
+
+  function elegirConsorcio(id: string) {
+    setSwitcherOpen(false);
+    setConsorcioActivo(id);
+  }
+
   function elegirTenant(id: string) {
     setTenantOverride(id);
     setTenantElegido(id);
@@ -101,11 +130,6 @@ export function Shell(_props: ShellProps): JSX.Element {
     return () => document.removeEventListener('mousedown', onOutside);
   }, [switcherOpen]);
 
-  function goToConsorcio(id: string) {
-    setSwitcherOpen(false);
-    nav(`/unidades?consorcio=${id}`);
-  }
-
   const initials = (user?.nombre ?? '?')
     .split(' ')
     .map((p) => p[0])
@@ -123,20 +147,22 @@ export function Shell(_props: ShellProps): JSX.Element {
   // decía uno mientras la pantalla trabajaba con el otro. Se muestra el nombre
   // solo cuando hay uno —ahí no hay ambigüedad posible— y si hay varios se dice
   // lo que el control realmente es.
+  // El super admin elige administración en este control; el admin elige consorcio.
+  // Es el mismo lugar porque en los dos casos es "en qué contexto estoy
+  // trabajando", pero el contexto que le corresponde a cada uno es distinto.
+  const nombreConsorcioActivo = consorcios.find((c) => c.id === consorcioActivo)?.nombre;
   const tituloSwitcher = esSuper
     ? (nombreTenant ?? 'Elegí administración')
     : totalConsorcios === 0
       ? 'Sin consorcios'
-      : totalConsorcios === 1
-        ? consorcios[0]!.nombre
-        : 'Mis consorcios';
+      : (nombreConsorcioActivo ?? 'Todos los consorcios');
   const subtituloSwitcher = esSuper
     ? (tenantElegido ? 'administración activa' : 'ninguna elegida')
     : totalConsorcios === 0
       ? 'agregá uno'
-      : totalConsorcios === 1
-        ? '1 consorcio'
-        : `${totalConsorcios} consorcios`;
+      : nombreConsorcioActivo
+        ? 'consorcio activo'
+        : `${totalConsorcios} en total`;
   const faltaElegirTenant = esSuper && !tenantElegido && loc.pathname !== '/administraciones';
 
   function onLogout() {
@@ -189,12 +215,27 @@ export function Shell(_props: ShellProps): JSX.Element {
               }}
             >
               {!esSuper && (
-                <div
-                  className="uppercase"
-                  style={{ padding: '4px 8px 6px', color: 'var(--cf-ink-3)', fontSize: 10.5 }}
-                >
-                  Ir a las unidades de
-                </div>
+                <>
+                  <div
+                    className="uppercase"
+                    style={{ padding: '4px 8px 6px', color: 'var(--cf-ink-3)', fontSize: 10.5 }}
+                  >
+                    Trabajar en
+                  </div>
+                  <button
+                    type="button"
+                    className="btn ghost sm"
+                    style={{
+                      width: '100%',
+                      justifyContent: 'flex-start',
+                      marginBottom: 2,
+                      fontWeight: consorcioActivo ? 500 : 700,
+                    }}
+                    onClick={() => elegirConsorcio('')}
+                  >
+                    Todos los consorcios
+                  </button>
+                </>
               )}
               {esSuper
                 ? tenants.map((t) => (
@@ -218,8 +259,13 @@ export function Shell(_props: ShellProps): JSX.Element {
                       key={c.id}
                       type="button"
                       className="btn ghost sm"
-                      style={{ width: '100%', justifyContent: 'flex-start', marginBottom: 2 }}
-                      onClick={() => goToConsorcio(c.id)}
+                      style={{
+                        width: '100%',
+                        justifyContent: 'flex-start',
+                        marginBottom: 2,
+                        fontWeight: c.id === consorcioActivo ? 700 : 500,
+                      }}
+                      onClick={() => elegirConsorcio(c.id)}
                     >
                       {c.nombre}
                     </button>

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -134,10 +134,41 @@ export interface Ticket {
   descripcionNormalizada: string;
   votosCount: number;
   categoriaId: string | null;
+  /** Unidad del vecino señalado; solo en CONDUCTA (RF-F01, migración 0004). */
+  unidadReportadaId: string | null;
   createdAt: string;
   validatedAt: string | null;
   solucionadoAt: string | null;
   updatedAt: string;
+  /** Solo presente en el detalle (GET /tickets/:id) y solo para admins. */
+  clasificacion?: ClasificacionIa | null;
+}
+
+/**
+ * Sugerencia del clasificador tal como quedó persistida. `null` cuando el
+ * ticket no pasó por la IA (lo cargó un admin a mano), que es distinto de
+ * "todavía no llegó".
+ */
+export interface ClasificacionIa {
+  sugerido: {
+    tipo?: TicketTipo;
+    origen?: TicketOrigen;
+    titulo?: string;
+    urgencia?: TicketUrgencia;
+    categoria?: string;
+    descripcion_normalizada?: string;
+    ubicacion?: string;
+    unidad_reportada_texto?: string;
+  };
+  corregidoPorAdmin: Record<string, unknown> | null;
+  confianza: number | null;
+  modelo: string;
+  promptVersion: string;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  costoUsd: string | null;
+  latenciaMs: number | null;
+  cacheHit: boolean;
 }
 
 export function listConsorcios(): Promise<Consorcio[]> {
@@ -201,9 +232,74 @@ export function listTickets(filters: {
 export function getTicket(id: string): Promise<Ticket> {
   return apiFetch<Ticket>(`/tickets/${id}`);
 }
+
+/**
+ * Carga manual de un ticket por el admin: alguien reporta por teléfono, en
+ * persona o en la reunión de consorcio. Es el criterio de salida de la Fase 1.
+ */
+export function createTicket(body: {
+  consorcio_id: string;
+  unidad_id: string | null;
+  tipo: TicketTipo;
+  urgencia: TicketUrgencia;
+  origen_sugerido?: TicketOrigen;
+  titulo: string;
+  descripcion: string;
+}): Promise<Ticket> {
+  return apiFetch<Ticket>('/tickets', { method: 'POST', body: JSON.stringify(body) });
+}
+
+/**
+ * Un evento del historial tal como lo devuelve la API. `nota`, `autorTipo` y
+ * `autorId` son opcionales a propósito: el service los omite según quién
+ * pregunta (en CONDUCTA un residente no recibe ni la nota ni el autor), así que
+ * el tipo tiene que admitir su ausencia y no fingir que siempre llegan.
+ */
+export interface HistorialEvento {
+  transicion: string;
+  estadoAnterior: TicketEstado | null;
+  estadoNuevo: TicketEstado | null;
+  nota?: string | null;
+  autorTipo?: string | null;
+  autorId?: string;
+  at: string;
+}
+
+/** Historial auditable del ticket (RF-D02). */
+export function getHistorial(id: string): Promise<HistorialEvento[]> {
+  return apiFetch<HistorialEvento[]>(`/tickets/${id}/historial`);
+}
+
+export interface Categoria {
+  id: string;
+  tenantId: string;
+  consorcioId: string;
+  nombre: string;
+  esConducta: boolean;
+  createdAt: string;
+}
+
+export function listCategorias(consorcioId?: string): Promise<Categoria[]> {
+  const q = consorcioId ? `?consorcio_id=${encodeURIComponent(consorcioId)}` : '';
+  return apiFetch<Categoria[]>(`/categorias${q}`);
+}
+export function createCategoria(body: {
+  consorcio_id: string;
+  nombre: string;
+  es_conducta?: boolean;
+}): Promise<Categoria> {
+  return apiFetch<Categoria>('/categorias', { method: 'POST', body: JSON.stringify(body) });
+}
 export function transitionTicket(
   id: string,
-  body: { to: TicketEstado; origen?: TicketOrigen; categoria_id?: string; nota?: string },
+  body: {
+    to: TicketEstado;
+    origen?: TicketOrigen;
+    categoria_id?: string;
+    nota?: string;
+    /** Obligatorio para validar una CONDUCTA (RF-F01). */
+    unidad_reportada_id?: string;
+  },
 ): Promise<Ticket> {
   return apiFetch<Ticket>(`/tickets/${id}/transitions`, {
     method: 'POST',
@@ -251,6 +347,20 @@ export interface MetricsOverview {
   byUrgencia: Array<{ urgencia: TicketUrgencia; count: number }>;
   avgResolutionMinutes: number | string | null;
   costosConfirmados: Array<{ moneda: string; total: number }>;
+  /**
+   * Telemetría del clasificador (RF-C07). La API la venía calculando y ninguna
+   * pantalla la declaraba, así que el dato existía y no se veía. `corregidosPorAdmin`
+   * es la métrica que importa para la tesis: cuántas veces la IA se equivocó.
+   */
+  costoIa: {
+    ticketsClasificados: number;
+    tokensIn: number;
+    tokensOut: number;
+    totalUsd: number;
+    promedioPorTicketUsd: number;
+    latenciaP50Ms: number;
+    corregidosPorAdmin: number;
+  };
 }
 
 export function getMetrics(consorcioId?: string): Promise<MetricsOverview> {
@@ -310,4 +420,68 @@ export interface SimilarTicket {
 }
 export function listSimilar(ticketId: string): Promise<SimilarTicket[]> {
   return apiFetch<SimilarTicket[]>(`/tickets/${ticketId}/similar`);
+}
+
+// ── Importación masiva de residentes (RF-A05) ────────────────────────────────
+
+export interface FilaError {
+  fila: number;
+  motivo: string;
+  datos: Record<string, string>;
+}
+
+export interface ResultadoImport {
+  totalFilas: number;
+  validas: number;
+  insertadas: number;
+  vinculosCreados: number;
+  vinculosYaExistentes: number;
+  reusados: Array<{ fila: number; telefono: string; nombreEnArchivo: string; nombreExistente: string }>;
+  errores: FilaError[];
+  dryRun: boolean;
+  unidadesCreadas: string[];
+}
+
+/**
+ * El CSV va como texto en el body, no como multipart: el panel lo lee con
+ * FileReader y así la API se ahorra multer. Con `dry_run` devuelve el mismo
+ * informe sin escribir nada, que es cómo el admin revisa una planilla de 200
+ * filas antes de aplicarla.
+ */
+export function importarResidentes(body: {
+  consorcio_id: string;
+  csv: string;
+  dry_run?: boolean;
+  crear_unidades?: boolean;
+}): Promise<ResultadoImport> {
+  return apiFetch<ResultadoImport>('/import/residentes', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Administraciones (RF-A01, solo SUPER_ADMIN) ───────────────────────────────
+
+export interface Tenant {
+  id: string;
+  nombre: string;
+  plan: string;
+  createdAt: string;
+}
+
+export function listTenants(): Promise<Tenant[]> {
+  return apiFetch<Tenant[]>('/tenants');
+}
+
+/**
+ * La administración se crea junto con su primer admin: un tenant sin nadie que
+ * pueda entrar no sirve, y hacerlo en dos pasos deja una ventana en la que la
+ * administración existe sin dueño.
+ */
+export function createTenant(body: {
+  nombre: string;
+  plan?: 'basico' | 'pro';
+  admin: { nombre: string; email: string; password: string };
+}): Promise<{ id: string; nombre: string; admin: { id: string; email: string } }> {
+  return apiFetch('/tenants', { method: 'POST', body: JSON.stringify(body) });
 }

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -182,6 +182,29 @@ export function createConsorcio(body: {
   return apiFetch<Consorcio>('/consorcios', { method: 'POST', body: JSON.stringify(body) });
 }
 
+/**
+ * Editar o archivar un consorcio. Archivar es un soft-delete: la fila se
+ * conserva porque los tickets viejos y su historial la referencian.
+ *
+ * El endpoint existía y ninguna pantalla lo llamaba: la lista mostraba el estado
+ * "Archivado" sin ninguna forma de llegar a ese estado, y un consorcio cargado
+ * con el nombre mal escrito no se podía corregir.
+ */
+export function updateConsorcio(
+  id: string,
+  body: { nombre?: string; direccion?: string; archivado?: boolean },
+): Promise<Consorcio> {
+  return apiFetch<Consorcio>(`/consorcios/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
+}
+
+/** Alta de muchas unidades de una vez: así se carga un edificio de verdad. */
+export function createUnidadesBulk(body: {
+  consorcio_id: string;
+  etiquetas: string[];
+}): Promise<Unidad[]> {
+  return apiFetch<Unidad[]>('/unidades/bulk', { method: 'POST', body: JSON.stringify(body) });
+}
+
 export function listUnidades(consorcioId?: string): Promise<Unidad[]> {
   const q = consorcioId ? `?consorcio_id=${encodeURIComponent(consorcioId)}` : '';
   return apiFetch<Unidad[]>(`/unidades${q}`);
@@ -380,11 +403,17 @@ export interface AuditEntry {
   at: string;
 }
 
-export function listAudit(q: { entidad?: string; accion?: string; days?: number } = {}): Promise<AuditEntry[]> {
+export function listAudit(
+  q: { entidad?: string; accion?: string; days?: number; limit?: number } = {},
+): Promise<AuditEntry[]> {
   const params = new URLSearchParams();
   if (q.entidad) params.set('entidad', q.entidad);
   if (q.accion) params.set('accion', q.accion);
   if (q.days) params.set('days', String(q.days));
+  // La API topea en 100 por defecto (máximo 500). El límite viaja explícito para
+  // que la pantalla sepa si lo que muestra está recortado y pueda decirlo: una
+  // bitácora que corta en silencio se lee como "no pasó nada más".
+  if (q.limit) params.set('limit', String(q.limit));
   const qs = params.toString();
   return apiFetch<AuditEntry[]>(`/admin/audit-log${qs ? `?${qs}` : ''}`);
 }

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -182,6 +182,20 @@ export function createConsorcio(body: {
   return apiFetch<Consorcio>('/consorcios', { method: 'POST', body: JSON.stringify(body) });
 }
 
+/**
+ * Aviso de que la lista de consorcios cambió.
+ *
+ * El Shell la carga una vez al montar para el selector de arriba, así que al
+ * crear el primer consorcio la barra seguía diciendo "Sin consorcios" hasta que
+ * recargabas la página. Un evento del navegador alcanza: es una sola lista, la
+ * cambian dos pantallas y no justifica traer un manejador de estado global.
+ */
+export const EVENTO_CONSORCIOS = 'cfx:consorcios-cambiaron';
+
+export function avisarConsorciosCambiaron(): void {
+  window.dispatchEvent(new Event(EVENTO_CONSORCIOS));
+}
+
 export function getConsorcio(id: string): Promise<Consorcio> {
   return apiFetch<Consorcio>(`/consorcios/${id}`);
 }

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -182,6 +182,10 @@ export function createConsorcio(body: {
   return apiFetch<Consorcio>('/consorcios', { method: 'POST', body: JSON.stringify(body) });
 }
 
+export function getConsorcio(id: string): Promise<Consorcio> {
+  return apiFetch<Consorcio>(`/consorcios/${id}`);
+}
+
 /**
  * Editar o archivar un consorcio. Archivar es un soft-delete: la fila se
  * conserva porque los tickets viejos y su historial la referencian.

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -9,6 +9,7 @@ export interface SessionUser {
 }
 
 const TOKEN_KEY = 'cfx.token';
+const REFRESH_KEY = 'cfx.refresh';
 const USER_KEY = 'cfx.user';
 const TENANT_KEY = 'cfx.tenant';
 const CONSORCIO_KEY = 'cfx.consorcio';
@@ -19,8 +20,12 @@ export function getToken(): string | null {
 export function setToken(t: string): void {
   sessionStorage.setItem(TOKEN_KEY, t);
 }
+export function setRefreshToken(t: string): void {
+  sessionStorage.setItem(REFRESH_KEY, t);
+}
 export function clearSession(): void {
   sessionStorage.removeItem(TOKEN_KEY);
+  sessionStorage.removeItem(REFRESH_KEY);
   sessionStorage.removeItem(USER_KEY);
   sessionStorage.removeItem(TENANT_KEY);
   sessionStorage.removeItem(CONSORCIO_KEY);
@@ -48,7 +53,48 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+/**
+ * Renueva el access token con el refresh, una sola vez a la vez.
+ *
+ * El login venía guardando solo el access token y el refresh se descartaba,
+ * aunque la respuesta lo trae y `POST /auth/refresh` existe desde el principio.
+ * Resultado: la sesión se moría en seco a los 15 minutos y la pantalla en la que
+ * estabas mostraba "invalid or expired token" en rojo.
+ *
+ * La promesa se comparte a propósito: si cinco pantallas piden datos al mismo
+ * tiempo y las cinco reciben 401, tiene que haber UN refresh y no cinco —el
+ * segundo usaría un refresh token que el primero ya rotó, y ahí sí se cae la
+ * sesión de verdad.
+ */
+let refreshEnCurso: Promise<boolean> | null = null;
+
+async function renovarToken(): Promise<boolean> {
+  const refresh = sessionStorage.getItem(REFRESH_KEY);
+  if (!refresh) return false;
+  refreshEnCurso ??= (async () => {
+    try {
+      const res = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ refreshToken: refresh }),
+      });
+      if (!res.ok) return false;
+      const j = (await res.json()) as { accessToken?: string; refreshToken?: string };
+      if (!j.accessToken) return false;
+      setToken(j.accessToken);
+      // El endpoint rota el refresh: guardar el nuevo o el próximo intento falla.
+      if (j.refreshToken) setRefreshToken(j.refreshToken);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshEnCurso = null;
+    }
+  })();
+  return refreshEnCurso;
+}
+
+async function pedir(path: string, init?: RequestInit): Promise<Response> {
   const headers = new Headers(init?.headers);
   if (!headers.has('content-type') && init?.body) headers.set('content-type', 'application/json');
   const token = getToken();
@@ -56,7 +102,29 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   const user = getUser();
   const tenantOverride = getTenantOverride();
   if (user?.kind === 'SUPER_ADMIN' && tenantOverride) headers.set('x-tenant-id', tenantOverride);
-  const res = await fetch(`/api${path}`, { ...init, headers });
+  return fetch(`/api${path}`, { ...init, headers });
+}
+
+export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  let res = await pedir(path, init);
+
+  // Un 401 casi siempre es el access token vencido, no una credencial mala: se
+  // renueva y se reintenta una vez. `/auth/*` se excluye para no entrar en bucle.
+  if (res.status === 401 && !path.startsWith('/auth/')) {
+    if (await renovarToken()) {
+      res = await pedir(path, init);
+    } else {
+      // El refresh también venció: la sesión terminó de verdad. Se limpia y se
+      // manda al login en vez de dejar al usuario mirando un error crudo en una
+      // pantalla que ya no puede cargar nada.
+      clearSession();
+      if (!window.location.pathname.startsWith('/login')) {
+        window.location.assign('/login');
+      }
+      throw new ApiError(401, 'Tu sesión expiró. Volvé a entrar.');
+    }
+  }
+
   if (!res.ok) {
     let detail = res.statusText;
     try {

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -514,3 +514,54 @@ export function createTenant(body: {
 }): Promise<{ id: string; nombre: string; admin: { id: string; email: string } }> {
   return apiFetch('/tenants', { method: 'POST', body: JSON.stringify(body) });
 }
+
+// ── Convivencia: avisos y sanciones (RF-F03) ─────────────────────────────────
+
+export type ResultadoConducta = 'DESCARTADO' | 'AVISO' | 'SANCION';
+
+export interface RegistroConducta {
+  id: string;
+  tenantId: string;
+  unidadId: string;
+  ticketId: string;
+  resultado: ResultadoConducta;
+  detalle: string | null;
+  createdAt: string;
+}
+
+export function listRegistrosConducta(ticketId: string): Promise<RegistroConducta[]> {
+  return apiFetch<RegistroConducta[]>(`/tickets/${ticketId}/registros-conducta`);
+}
+
+/**
+ * Registra el resultado del reporte de conducta. Queda asentado contra la unidad
+ * SEÑALADA en el ticket, no contra la del denunciante, y va a la bitácora.
+ */
+export function createRegistroConducta(
+  ticketId: string,
+  body: { resultado: ResultadoConducta; detalle?: string },
+): Promise<RegistroConducta> {
+  return apiFetch<RegistroConducta>(`/tickets/${ticketId}/registros-conducta`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+export interface EventoConvivencia {
+  id: string;
+  ticketId: string;
+  resultado: ResultadoConducta;
+  detalle: string | null;
+  createdAt: string;
+  ticketTitulo: string;
+  ticketEstado: TicketEstado;
+}
+
+/**
+ * Historial de convivencia de una unidad: todos los avisos y sanciones que se le
+ * registraron, a través de cualquier ticket de conducta. Es lo que permite ver
+ * que es la cuarta vez, no la primera. Solo lo consulta la administración (P5).
+ */
+export function historialConducta(unidadId: string): Promise<EventoConvivencia[]> {
+  return apiFetch<EventoConvivencia[]>(`/unidades/${unidadId}/historial-conducta`);
+}

--- a/apps/admin-web/src/lib/api.ts
+++ b/apps/admin-web/src/lib/api.ts
@@ -11,6 +11,7 @@ export interface SessionUser {
 const TOKEN_KEY = 'cfx.token';
 const USER_KEY = 'cfx.user';
 const TENANT_KEY = 'cfx.tenant';
+const CONSORCIO_KEY = 'cfx.consorcio';
 
 export function getToken(): string | null {
   return sessionStorage.getItem(TOKEN_KEY);
@@ -22,6 +23,7 @@ export function clearSession(): void {
   sessionStorage.removeItem(TOKEN_KEY);
   sessionStorage.removeItem(USER_KEY);
   sessionStorage.removeItem(TENANT_KEY);
+  sessionStorage.removeItem(CONSORCIO_KEY);
 }
 export function getUser(): SessionUser | null {
   const raw = sessionStorage.getItem(USER_KEY);
@@ -35,6 +37,9 @@ export function getTenantOverride(): string | null {
 }
 export function setTenantOverride(t: string): void {
   sessionStorage.setItem(TENANT_KEY, t);
+  // El consorcio elegido pertenecía a la administración anterior: mantenerlo
+  // dejaría a las pantallas filtrando por un id que la nueva no puede ver.
+  sessionStorage.removeItem(CONSORCIO_KEY);
 }
 
 export class ApiError extends Error {
@@ -194,6 +199,41 @@ export const EVENTO_CONSORCIOS = 'cfx:consorcios-cambiaron';
 
 export function avisarConsorciosCambiaron(): void {
   window.dispatchEvent(new Event(EVENTO_CONSORCIOS));
+}
+
+/**
+ * Consorcio con el que está trabajando el admin, compartido por todas las
+ * pantallas.
+ *
+ * Antes cada pantalla arrancaba con su propio filtro en "Todos", así que elegir
+ * un consorcio en la Bandeja y pasar a Resumen te devolvía a todos. Y el control
+ * del sidebar no seleccionaba nada: navegaba a las unidades de ese consorcio.
+ *
+ * Cadena vacía significa "todos" y es un valor válido, así que se distingue de
+ * `null` (nunca se eligió). Vive en `sessionStorage` como el token y la
+ * administración elegida: se va al cerrar sesión y no sobrevive a cerrar la
+ * pestaña, que para un panel de trabajo es lo que se espera.
+ */
+export const EVENTO_CONSORCIO_ACTIVO = 'cfx:consorcio-activo';
+
+export function getConsorcioActivo(): string | null {
+  return sessionStorage.getItem(CONSORCIO_KEY);
+}
+
+export function setConsorcioActivo(id: string): void {
+  sessionStorage.setItem(CONSORCIO_KEY, id);
+  window.dispatchEvent(new Event(EVENTO_CONSORCIO_ACTIVO));
+}
+
+/**
+ * Olvida la elección. Se llama cuando el consorcio guardado ya no existe (lo
+ * archivaron, o el super admin cambió de administración y ese id pertenece a la
+ * anterior): dejarlo puesto haría que las pantallas filtren por un id fantasma y
+ * muestren vacío sin explicar por qué.
+ */
+export function limpiarConsorcioActivo(): void {
+  sessionStorage.removeItem(CONSORCIO_KEY);
+  window.dispatchEvent(new Event(EVENTO_CONSORCIO_ACTIVO));
 }
 
 export function getConsorcio(id: string): Promise<Consorcio> {

--- a/apps/admin-web/src/pages/AdministracionesPage.tsx
+++ b/apps/admin-web/src/pages/AdministracionesPage.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState, type FormEvent } from 'react';
+import { Icons } from '../components/Icons.js';
+import { Topbar } from '../components/Shell.js';
+import { createTenant, listTenants, type Tenant } from '../lib/api.js';
+import { useAuth } from '../lib/auth-ctx.js';
+
+/**
+ * ABM de administraciones (RF-A01). Solo SUPER_ADMIN.
+ *
+ * El endpoint existía desde el PR #38 y no había pantalla: dar de alta un
+ * cliente nuevo del SaaS —lo primero que pasa cuando alguien compra— había que
+ * hacerlo con un INSERT a mano en la base.
+ *
+ * La administración se crea junto con su primer admin en una sola transacción:
+ * un tenant sin nadie que pueda entrar no sirve para nada, y hacerlo en dos
+ * pasos deja una ventana en la que existe una administración sin dueño.
+ */
+export function AdministracionesPage(): JSX.Element {
+  const { user } = useAuth();
+  const [items, setItems] = useState<Tenant[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+
+  const [nombre, setNombre] = useState('');
+  const [plan, setPlan] = useState<'basico' | 'pro'>('basico');
+  const [adminNombre, setAdminNombre] = useState('');
+  const [adminEmail, setAdminEmail] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+
+  function load() {
+    listTenants()
+      .then(setItems)
+      .catch((e) => setError((e as Error).message));
+  }
+  useEffect(load, []);
+
+  if (user?.kind !== 'SUPER_ADMIN') {
+    return (
+      <>
+        <Topbar title="Administraciones" />
+        <div className="content">
+          <section>
+            <div className="error">
+              Esta sección es solo para el super administrador de la plataforma.
+            </div>
+          </section>
+        </div>
+      </>
+    );
+  }
+
+  async function onCreate(e: FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    setOk(null);
+    try {
+      const creado = await createTenant({
+        nombre,
+        plan,
+        admin: { nombre: adminNombre, email: adminEmail, password: adminPassword },
+      });
+      setOk(`Se creó “${creado.nombre}”. Su administrador ya puede entrar con ${creado.admin.email}.`);
+      setNombre('');
+      setAdminNombre('');
+      setAdminEmail('');
+      setAdminPassword('');
+      setShowForm(false);
+      load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Topbar
+        title="Administraciones"
+        subtitle={`${items.length} ${items.length === 1 ? 'administración' : 'administraciones'} en la plataforma`}
+        actions={
+          <button type="button" className="btn primary" onClick={() => setShowForm((s) => !s)}>
+            <Icons.plus size={14} sw={2.2} /> {showForm ? 'Cancelar' : 'Nueva administración'}
+          </button>
+        }
+      />
+      <div className="content">
+        <section className="stack">
+          {error && <div className="error">{error}</div>}
+          {ok && <div className="chip ok">{ok}</div>}
+
+          {showForm && (
+            <form className="card form-grid" onSubmit={onCreate}>
+              <div style={{ fontSize: 13, fontWeight: 600 }}>Alta de una administración</div>
+              <label>
+                <span>Nombre de la administración</span>
+                <input value={nombre} onChange={(e) => setNombre(e.target.value)} required minLength={2} maxLength={140} placeholder="Ej. Administración Rivadavia" />
+              </label>
+              <label>
+                <span>Plan</span>
+                <select value={plan} onChange={(e) => setPlan(e.target.value as 'basico' | 'pro')}>
+                  <option value="basico">Básico</option>
+                  <option value="pro">Pro</option>
+                </select>
+              </label>
+
+              <div className="uppercase mt-2">Su primer administrador</div>
+              <label>
+                <span>Nombre</span>
+                <input value={adminNombre} onChange={(e) => setAdminNombre(e.target.value)} required minLength={2} maxLength={140} />
+              </label>
+              <label>
+                <span>Email</span>
+                <input type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} required />
+              </label>
+              <label>
+                <span>Contraseña</span>
+                {/* 10 caracteres, no 6: es la cuenta que administra un tenant
+                    entero. Lo exige la API, así que el mínimo del form coincide
+                    para que el error salte acá y no después de enviar. */}
+                <input
+                  type="password"
+                  value={adminPassword}
+                  onChange={(e) => setAdminPassword(e.target.value)}
+                  required
+                  minLength={10}
+                  maxLength={200}
+                  placeholder="Mínimo 10 caracteres"
+                />
+              </label>
+              <button type="submit" className="btn primary" disabled={busy || !nombre || !adminEmail || adminPassword.length < 10}>
+                {busy ? 'Creando…' : 'Crear administración y su admin'}
+              </button>
+            </form>
+          )}
+
+          <div className="card">
+            {items.length === 0 ? (
+              <div className="muted small">Todavía no hay administraciones.</div>
+            ) : (
+              <table className="grid">
+                <thead>
+                  <tr>
+                    <th>Administración</th>
+                    <th>Plan</th>
+                    <th>Alta</th>
+                    <th>Id</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((t) => (
+                    <tr key={t.id}>
+                      <td><strong>{t.nombre}</strong></td>
+                      <td><span className="chip">{t.plan}</span></td>
+                      <td className="muted small">{new Date(t.createdAt).toLocaleDateString('es-AR')}</td>
+                      <td className="mono small">{t.id.slice(0, 8)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/apps/admin-web/src/pages/AdministracionesPage.tsx
+++ b/apps/admin-web/src/pages/AdministracionesPage.tsx
@@ -29,14 +29,22 @@ export function AdministracionesPage(): JSX.Element {
   const [adminEmail, setAdminEmail] = useState('');
   const [adminPassword, setAdminPassword] = useState('');
 
+  const esSuper = user?.kind === 'SUPER_ADMIN';
+  const [cargando, setCargando] = useState(esSuper);
+
   function load() {
+    // La API responde 403 a un ADMIN, así que no se pide: abajo se muestra el
+    // aviso de que la sección no le corresponde y el pedido no aportaría nada.
+    if (!esSuper) return;
+    setCargando(true);
     listTenants()
       .then(setItems)
-      .catch((e) => setError((e as Error).message));
+      .catch((e) => setError((e as Error).message))
+      .finally(() => setCargando(false));
   }
-  useEffect(load, []);
+  useEffect(load, [esSuper]);
 
-  if (user?.kind !== 'SUPER_ADMIN') {
+  if (!esSuper) {
     return (
       <>
         <Topbar title="Administraciones" />
@@ -139,7 +147,9 @@ export function AdministracionesPage(): JSX.Element {
 
           <div className="card">
             {items.length === 0 ? (
-              <div className="muted small">Todavía no hay administraciones.</div>
+              <div className="muted small">
+                {cargando ? 'Cargando…' : error ? 'No se pudo cargar la lista.' : 'Todavía no hay administraciones.'}
+              </div>
             ) : (
               <table className="grid">
                 <thead>

--- a/apps/admin-web/src/pages/AdministracionesPage.tsx
+++ b/apps/admin-web/src/pages/AdministracionesPage.tsx
@@ -84,6 +84,19 @@ export function AdministracionesPage(): JSX.Element {
     }
   }
 
+  // Qué falta para poder crear, en palabras. La contraseña son 10 caracteres y no
+  // 6 porque es la cuenta que administra un tenant entero; lo exige la API, así
+  // que el formulario lo dice antes de que el intento falle.
+  const falta = !nombre.trim()
+    ? 'el nombre de la administración'
+    : !adminNombre.trim()
+      ? 'el nombre del administrador'
+      : !adminEmail.trim()
+        ? 'el email del administrador'
+        : adminPassword.length < 10
+          ? `${10 - adminPassword.length} caracter${10 - adminPassword.length === 1 ? '' : 'es'} más en la contraseña (mínimo 10)`
+          : null;
+
   return (
     <>
       <Topbar
@@ -102,7 +115,7 @@ export function AdministracionesPage(): JSX.Element {
 
           {showForm && (
             <form className="card form-grid" onSubmit={onCreate}>
-              <div style={{ fontSize: 13, fontWeight: 600 }}>Alta de una administración</div>
+              <div className="form-full" style={{ fontSize: 13, fontWeight: 600 }}>Alta de una administración</div>
               <label>
                 <span>Nombre de la administración</span>
                 <input value={nombre} onChange={(e) => setNombre(e.target.value)} required minLength={2} maxLength={140} placeholder="Ej. Administración Rivadavia" />
@@ -115,7 +128,9 @@ export function AdministracionesPage(): JSX.Element {
                 </select>
               </label>
 
-              <div className="uppercase mt-2">Su primer administrador</div>
+              <div className="form-full uppercase mt-2" style={{ borderTop: '1px solid var(--cf-line)', paddingTop: 12 }}>
+                Su primer administrador
+              </div>
               <label>
                 <span>Nombre</span>
                 <input value={adminNombre} onChange={(e) => setAdminNombre(e.target.value)} required minLength={2} maxLength={140} />
@@ -139,7 +154,12 @@ export function AdministracionesPage(): JSX.Element {
                   placeholder="Mínimo 10 caracteres"
                 />
               </label>
-              <button type="submit" className="btn primary" disabled={busy || !nombre || !adminEmail || adminPassword.length < 10}>
+              {/* Un botón gris sin explicación es un callejón sin salida: se ve
+                  que no se puede seguir y no se sabe qué falta. */}
+              {falta && (
+                <div className="form-full muted small">Falta: {falta}.</div>
+              )}
+              <button type="submit" className="btn primary" disabled={busy || falta !== null}>
                 {busy ? 'Creando…' : 'Crear administración y su admin'}
               </button>
             </form>

--- a/apps/admin-web/src/pages/AuditPage.tsx
+++ b/apps/admin-web/src/pages/AuditPage.tsx
@@ -38,6 +38,10 @@ export function AuditPage(): JSX.Element {
   const [days, setDays] = useState<number>(30);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // La API topea en 500. Se pide un tramo y se avisa cuando lo que se muestra
+  // está recortado: antes traía las 100 por defecto sin decirlo, y una bitácora
+  // que corta en silencio se lee como "no pasó nada más".
+  const [limit, setLimit] = useState(100);
 
   useEffect(() => {
     setLoading(true);
@@ -45,11 +49,14 @@ export function AuditPage(): JSX.Element {
     listAudit({
       ...(entidadFilter && { entidad: entidadFilter }),
       days,
+      limit,
     })
       .then(setEntries)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [entidadFilter, days]);
+  }, [entidadFilter, days, limit]);
+
+  const recortado = entries.length >= limit;
 
   return (
     <>
@@ -96,7 +103,15 @@ export function AuditPage(): JSX.Element {
             </div>
           </div>
           <div className="spacer" />
-          <span style={{ fontSize: 12, color: 'var(--cf-ink-3)' }}>{entries.length} eventos</span>
+          <span style={{ fontSize: 12, color: 'var(--cf-ink-3)' }}>
+            {entries.length} eventos
+            {recortado && ' (recortado)'}
+          </span>
+          {recortado && limit < 500 && (
+            <button type="button" className="btn ghost sm" onClick={() => setLimit(500)} disabled={loading}>
+              Ver más
+            </button>
+          )}
         </div>
 
         <section>

--- a/apps/admin-web/src/pages/BandejaPage.tsx
+++ b/apps/admin-web/src/pages/BandejaPage.tsx
@@ -243,7 +243,12 @@ export function BandejaPage(): JSX.Element {
     <>
       <Topbar
         title="Bandeja de entrada"
-        subtitle={`${sinTriar} sin triar · IA pre-clasifica cada nuevo reporte`}
+        // "IA pre-clasifica cada nuevo reporte" no era exacto: solo los reportes
+        // que entran por el bot pasan por el clasificador. Los que se cargan
+        // desde la app o a mano llegan sin clasificar, y prometer lo contrario
+        // en la pantalla que usa la administradora todos los días es sembrar
+        // desconfianza en el resto de los números.
+        subtitle={`${sinTriar} sin triar · los reportes del bot llegan pre-clasificados por IA`}
         actions={
           <>
             <button type="button" className="btn ghost" onClick={onExportar} disabled={sorted.length === 0}>
@@ -282,7 +287,11 @@ export function BandejaPage(): JSX.Element {
             <div className="kpi">
               <div className="kpi-label">Tiempo medio resol.</div>
               <div className="kpi-value">{ttrLabel}</div>
-              <div className="kpi-delta ok">métrica del tenant</div>
+              {/* Decía "métrica del tenant": "tenant" es vocabulario del código,
+                  no de la administradora que lee esta pantalla (regla 8). Y el
+                  promedio solo considera los tickets resueltos, que es el dato
+                  que de verdad hay que aclarar acá. */}
+              <div className="kpi-delta ok">solo tickets resueltos</div>
             </div>
             <div className="kpi">
               <div className="kpi-label">Gastos confirmados</div>

--- a/apps/admin-web/src/pages/BandejaPage.tsx
+++ b/apps/admin-web/src/pages/BandejaPage.tsx
@@ -1,16 +1,21 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
+  createTicket,
   getMetrics,
   listConsorcios,
   listTickets,
+  listUnidades,
   type Consorcio,
   type MetricsOverview,
   type Ticket,
   type TicketEstado,
+  type TicketOrigen,
+  type TicketTipo,
   type TicketUrgencia,
+  type Unidad,
 } from '../lib/api.js';
 
 const URGENCIA_RANK: Record<string, number> = { CRITICA: 0, ALTA: 1, MEDIA: 2, BAJA: 3 };
@@ -50,18 +55,88 @@ function relativeTime(iso: string): string {
   return new Date(iso).toLocaleDateString('es-AR');
 }
 
+/**
+ * CSV del listado que el admin está viendo.
+ *
+ * Se arma en el cliente sobre los tickets ya cargados en vez de agregar un
+ * endpoint de export: es exactamente lo que la pantalla muestra (mismos
+ * filtros, mismo orden), no hay que mantener dos definiciones de "la bandeja",
+ * y para los volúmenes de un consorcio no justifica más superficie de API.
+ */
+function toCsv(rows: Ticket[], nombreConsorcio: (id: string) => string): string {
+  const cols = ['id', 'titulo', 'tipo', 'origen', 'urgencia', 'estado', 'votos', 'consorcio', 'creado'];
+  const esc = (v: unknown): string => {
+    const s = String(v ?? '');
+    // Excel en es-AR abre con separador ; pero el estándar es , — se citan
+    // todos los campos, así que da igual cuál interprete.
+    return `"${s.replace(/"/g, '""')}"`;
+  };
+  const lineas = rows.map((t) =>
+    [
+      t.id,
+      t.titulo,
+      t.tipo,
+      t.origen ?? 'sin validar',
+      t.urgencia,
+      t.estado,
+      t.votosCount,
+      nombreConsorcio(t.consorcioId),
+      new Date(t.createdAt).toISOString(),
+    ]
+      .map(esc)
+      .join(','),
+  );
+  // BOM para que Excel reconozca UTF-8 y no rompa los acentos.
+  return `\ufeff${cols.map(esc).join(',')}\n${lineas.join('\n')}\n`;
+}
+
 export function BandejaPage(): JSX.Element {
+  const navigate = useNavigate();
   const [consorcios, setConsorcios] = useState<Consorcio[]>([]);
   const [consorcioFilter, setConsorcioFilter] = useState<string>('');
   const [estadoFilter, setEstadoFilter] = useState<TicketEstado | ''>('REGISTRADO');
+  const [busqueda, setBusqueda] = useState('');
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [metrics, setMetrics] = useState<MetricsOverview | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Alta manual (RF-B01 por mostrador): alguien reporta por teléfono o en la
+  // reunión de consorcio y el admin lo carga a mano.
+  const [showNuevo, setShowNuevo] = useState(false);
+  const [nvConsorcio, setNvConsorcio] = useState('');
+  const [nvUnidades, setNvUnidades] = useState<Unidad[]>([]);
+  const [nvUnidad, setNvUnidad] = useState('');
+  const [nvTipo, setNvTipo] = useState<TicketTipo>('INFRAESTRUCTURA');
+  const [nvOrigen, setNvOrigen] = useState<TicketOrigen>('ESPACIO_COMUN');
+  const [nvUrgencia, setNvUrgencia] = useState<TicketUrgencia>('MEDIA');
+  const [nvTitulo, setNvTitulo] = useState('');
+  const [nvDesc, setNvDesc] = useState('');
+  const [creando, setCreando] = useState(false);
+
   useEffect(() => {
     listConsorcios().then(setConsorcios).catch((e) => setError(e.message));
   }, []);
+
+  // Unidades del consorcio elegido en el alta manual.
+  useEffect(() => {
+    if (!nvConsorcio) {
+      setNvUnidades([]);
+      setNvUnidad('');
+      return;
+    }
+    let vigente = true;
+    listUnidades(nvConsorcio)
+      .then((us) => {
+        if (vigente) setNvUnidades(us);
+      })
+      .catch(() => {
+        if (vigente) setNvUnidades([]);
+      });
+    return () => {
+      vigente = false;
+    };
+  }, [nvConsorcio]);
 
   useEffect(() => {
     setLoading(true);
@@ -81,15 +156,65 @@ export function BandejaPage(): JSX.Element {
       .finally(() => setLoading(false));
   }, [consorcioFilter, estadoFilter]);
 
+  const nombreConsorcio = (cid: string): string =>
+    consorcios.find((c) => c.id === cid)?.nombre ?? cid.slice(0, 8);
+
+  async function onCrearTicket(e: FormEvent) {
+    e.preventDefault();
+    setCreando(true);
+    setError(null);
+    try {
+      const creado = await createTicket({
+        consorcio_id: nvConsorcio,
+        // En espacio común no hay unidad imputada; en conducta la unidad
+        // señalada se confirma al validar (RF-F01), no acá.
+        unidad_id: nvOrigen === 'UNIDAD' && nvUnidad ? nvUnidad : null,
+        tipo: nvTipo,
+        urgencia: nvUrgencia,
+        ...(nvTipo === 'INFRAESTRUCTURA' && { origen_sugerido: nvOrigen }),
+        titulo: nvTitulo,
+        descripcion: nvDesc,
+      });
+      setShowNuevo(false);
+      setNvTitulo('');
+      setNvDesc('');
+      navigate(`/tickets/${creado.id}`);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setCreando(false);
+    }
+  }
+
+  function onExportar() {
+    const csv = toCsv(sorted, nombreConsorcio);
+    const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }));
+    const a = document.createElement('a');
+    a.href = url;
+    const scope = consorcioFilter ? nombreConsorcio(consorcioFilter).replace(/\W+/g, '-') : 'todos';
+    a.download = `bandeja-${scope}-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   const sorted = useMemo(() => {
-    return [...tickets].sort((a, b) => {
+    const q = busqueda.trim().toLowerCase();
+    const filtrados = q
+      ? tickets.filter(
+          (t) =>
+            t.titulo.toLowerCase().includes(q) ||
+            t.descripcionNormalizada.toLowerCase().includes(q) ||
+            t.id.toLowerCase().startsWith(q),
+        )
+      : tickets;
+    return [...filtrados].sort((a, b) => {
       const ua = URGENCIA_RANK[a.urgencia] ?? 99;
       const ub = URGENCIA_RANK[b.urgencia] ?? 99;
       if (ua !== ub) return ua - ub;
       if (a.votosCount !== b.votosCount) return b.votosCount - a.votosCount;
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     });
-  }, [tickets]);
+  }, [tickets, busqueda]);
 
   const countByEstado = useMemo(() => {
     const m: Record<string, number> = {};
@@ -120,8 +245,20 @@ export function BandejaPage(): JSX.Element {
         subtitle={`${sinTriar} sin triar · IA pre-clasifica cada nuevo reporte`}
         actions={
           <>
-            <button type="button" className="btn ghost"><Icons.filter size={14} />Exportar</button>
-            <button type="button" className="btn primary"><Icons.plus size={14} sw={2.2} />Nuevo reporte</button>
+            <button type="button" className="btn ghost" onClick={onExportar} disabled={sorted.length === 0}>
+              <Icons.filter size={14} />Exportar CSV
+            </button>
+            <button
+              type="button"
+              className="btn primary"
+              onClick={() => {
+                setNvConsorcio(consorcioFilter || consorcios[0]?.id || '');
+                setShowNuevo((v) => !v);
+              }}
+              disabled={consorcios.length === 0}
+            >
+              <Icons.plus size={14} sw={2.2} />{showNuevo ? 'Cancelar' : 'Nuevo reporte'}
+            </button>
           </>
         }
       />
@@ -178,9 +315,98 @@ export function BandejaPage(): JSX.Element {
               ))}
             </div>
           </div>
+          <div className="filter-divider" />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span className="uppercase">Buscar</span>
+            {/* Filtra sobre lo ya cargado: título, descripción y prefijo del id.
+                La API acota por consorcio y estado; el texto se resuelve acá
+                para no pedir de nuevo en cada tecla. */}
+            <input
+              value={busqueda}
+              onChange={(e) => setBusqueda(e.target.value)}
+              placeholder="Título, texto o #id"
+              style={{ height: 32, minWidth: 200 }}
+            />
+            {busqueda && (
+              <button type="button" className="btn ghost sm" onClick={() => setBusqueda('')}>Limpiar</button>
+            )}
+          </div>
           <div className="spacer" />
           <span style={{ fontSize: 12, color: 'var(--cf-ink-3)' }}>{sorted.length} resultados</span>
         </div>
+
+        {showNuevo && (
+          <section style={{ paddingTop: 0 }}>
+            <form className="form-grid card" onSubmit={onCrearTicket}>
+              <div style={{ fontSize: 13, fontWeight: 600 }}>Cargar un reporte a mano</div>
+              <div className="muted small">
+                Para lo que llega por teléfono, en persona o en la reunión de consorcio. Queda sin
+                reportante: el ticket es de la administración.
+              </div>
+              <label>
+                <span>Consorcio</span>
+                <select value={nvConsorcio} onChange={(e) => setNvConsorcio(e.target.value)} required>
+                  <option value="">Elegí un consorcio…</option>
+                  {consorcios.map((c) => (
+                    <option key={c.id} value={c.id}>{c.nombre}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>Tipo</span>
+                <select value={nvTipo} onChange={(e) => setNvTipo(e.target.value as TicketTipo)}>
+                  <option value="INFRAESTRUCTURA">Infraestructura</option>
+                  <option value="CONDUCTA">Conducta</option>
+                </select>
+              </label>
+              {nvTipo === 'INFRAESTRUCTURA' && (
+                <label>
+                  <span>Origen</span>
+                  <select value={nvOrigen} onChange={(e) => setNvOrigen(e.target.value as TicketOrigen)}>
+                    <option value="ESPACIO_COMUN">Espacio común — lo ven todos los vecinos</option>
+                    <option value="UNIDAD">Unidad — solo la administración y sus ocupantes</option>
+                  </select>
+                </label>
+              )}
+              {nvTipo === 'INFRAESTRUCTURA' && nvOrigen === 'UNIDAD' && (
+                <label>
+                  <span>Unidad afectada</span>
+                  <select value={nvUnidad} onChange={(e) => setNvUnidad(e.target.value)} required>
+                    <option value="">Elegí una unidad…</option>
+                    {nvUnidades.map((u) => (
+                      <option key={u.id} value={u.id}>{u.etiqueta}</option>
+                    ))}
+                  </select>
+                </label>
+              )}
+              {nvTipo === 'CONDUCTA' && (
+                <div className="muted small">
+                  La unidad señalada se confirma al validar el ticket, no ahora.
+                </div>
+              )}
+              <label>
+                <span>Urgencia</span>
+                <select value={nvUrgencia} onChange={(e) => setNvUrgencia(e.target.value as TicketUrgencia)}>
+                  <option value="CRITICA">Crítica</option>
+                  <option value="ALTA">Alta</option>
+                  <option value="MEDIA">Media</option>
+                  <option value="BAJA">Baja</option>
+                </select>
+              </label>
+              <label>
+                <span>Título</span>
+                <input value={nvTitulo} onChange={(e) => setNvTitulo(e.target.value)} required minLength={3} maxLength={140} />
+              </label>
+              <label>
+                <span>Qué pasó</span>
+                <textarea rows={3} value={nvDesc} onChange={(e) => setNvDesc(e.target.value)} required maxLength={4000} />
+              </label>
+              <button type="submit" className="btn primary" disabled={creando || !nvConsorcio || !nvTitulo || !nvDesc}>
+                {creando ? 'Creando…' : 'Crear reporte'}
+              </button>
+            </form>
+          </section>
+        )}
 
         <div className="inbox-row-head">
           <span />
@@ -217,9 +443,18 @@ export function BandejaPage(): JSX.Element {
                   {t.tipo === 'CONDUCTA' ? 'Conducta' : t.origen === 'ESPACIO_COMUN' ? 'Espacio común' : 'Unidad'} · {relativeTime(t.createdAt)}
                 </div>
               </div>
+              {/* Antes decía "Bot / App" en todos los tickets, incluidos los
+                  que el admin cargaba a mano. `reportanteId` es null justamente
+                  cuando no hubo un residente reportando. */}
               <div style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 12, color: 'var(--cf-ink-2)' }}>
-                <Icons.whatsapp size={14} stroke="var(--cf-whatsapp-dk)" fill="var(--cf-whatsapp-dk)" />
-                <span>Bot / App</span>
+                {t.reportanteId ? (
+                  <>
+                    <Icons.whatsapp size={14} stroke="var(--cf-whatsapp-dk)" fill="var(--cf-whatsapp-dk)" />
+                    <span>Bot / App</span>
+                  </>
+                ) : (
+                  <span className="muted">Carga manual</span>
+                )}
               </div>
               <div>
                 <span className={`chip ${u.cls}`}>

--- a/apps/admin-web/src/pages/BandejaPage.tsx
+++ b/apps/admin-web/src/pages/BandejaPage.tsx
@@ -341,8 +341,8 @@ export function BandejaPage(): JSX.Element {
         {showNuevo && (
           <section style={{ paddingTop: 0 }}>
             <form className="form-grid card" onSubmit={onCrearTicket}>
-              <div style={{ fontSize: 13, fontWeight: 600 }}>Cargar un reporte a mano</div>
-              <div className="muted small">
+              <div className="form-full" style={{ fontSize: 13, fontWeight: 600 }}>Cargar un reporte a mano</div>
+              <div className="form-full muted small">
                 Para lo que llega por teléfono, en persona o en la reunión de consorcio. Queda sin
                 reportante: el ticket es de la administración.
               </div>
@@ -383,7 +383,7 @@ export function BandejaPage(): JSX.Element {
                 </label>
               )}
               {nvTipo === 'CONDUCTA' && (
-                <div className="muted small">
+                <div className="form-full muted small">
                   La unidad señalada se confirma al validar el ticket, no ahora.
                 </div>
               )}
@@ -400,7 +400,7 @@ export function BandejaPage(): JSX.Element {
                 <span>Título</span>
                 <input value={nvTitulo} onChange={(e) => setNvTitulo(e.target.value)} required minLength={3} maxLength={140} />
               </label>
-              <label>
+              <label className="form-full">
                 <span>Qué pasó</span>
                 <textarea rows={3} value={nvDesc} onChange={(e) => setNvDesc(e.target.value)} required maxLength={4000} />
               </label>

--- a/apps/admin-web/src/pages/BandejaPage.tsx
+++ b/apps/admin-web/src/pages/BandejaPage.tsx
@@ -3,7 +3,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
+  EVENTO_CONSORCIO_ACTIVO,
   createTicket,
+  getConsorcioActivo,
+  setConsorcioActivo,
   getMetrics,
   listConsorcios,
   listTickets,
@@ -93,7 +96,15 @@ function toCsv(rows: Ticket[], nombreConsorcio: (id: string) => string): string 
 export function BandejaPage(): JSX.Element {
   const navigate = useNavigate();
   const [consorcios, setConsorcios] = useState<Consorcio[]>([]);
-  const [consorcioFilter, setConsorcioFilter] = useState<string>('');
+  // El consorcio activo lo comparten todas las pantallas: si lo elegiste en el
+  // sidebar o en el Resumen, la Bandeja arranca ahí y no en "Todos".
+  const [consorcioFilter, setConsorcioFilter] = useState<string>(getConsorcioActivo() ?? '');
+
+  useEffect(() => {
+    const sincronizar = () => setConsorcioFilter(getConsorcioActivo() ?? '');
+    window.addEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+    return () => window.removeEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+  }, []);
   const [estadoFilter, setEstadoFilter] = useState<TicketEstado | ''>('REGISTRADO');
   const [busqueda, setBusqueda] = useState('');
   const [tickets, setTickets] = useState<Ticket[]>([]);
@@ -304,7 +315,7 @@ export function BandejaPage(): JSX.Element {
         <div className="filters-bar">
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span className="uppercase">Consorcio</span>
-            <select value={consorcioFilter} onChange={(e) => setConsorcioFilter(e.target.value)} style={{ minWidth: 200, height: 32 }}>
+            <select value={consorcioFilter} onChange={(e) => setConsorcioActivo(e.target.value)} style={{ minWidth: 200, height: 32 }}>
               <option value="">Todos</option>
               {consorcios.map((c) => (
                 <option key={c.id} value={c.id}>{c.nombre}</option>

--- a/apps/admin-web/src/pages/BandejaPage.tsx
+++ b/apps/admin-web/src/pages/BandejaPage.tsx
@@ -237,6 +237,7 @@ export function BandejaPage(): JSX.Element {
         : `${(ttrMin / (60 * 24)).toFixed(1)} d`
     : '—';
   const gastoARS = metrics?.costosConfirmados.find((c) => c.moneda === 'ARS')?.total ?? 0;
+  const ambito = consorcioFilter ? 'en este consorcio' : 'en toda la administración';
 
   return (
     <>
@@ -269,7 +270,9 @@ export function BandejaPage(): JSX.Element {
             <div className="kpi">
               <div className="kpi-label">Sin triar</div>
               <div className="kpi-value">{sinTriar}</div>
-              <div className="kpi-delta">en este consorcio</div>
+              {/* Decía "en este consorcio" siempre, también con el filtro en
+                  "Todos", donde el número es de toda la administración. */}
+              <div className="kpi-delta">{ambito}</div>
             </div>
             <div className="kpi">
               <div className="kpi-label">Alta urgencia</div>

--- a/apps/admin-web/src/pages/ConsorciosPage.tsx
+++ b/apps/admin-web/src/pages/ConsorciosPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
-import { createConsorcio, listConsorcios, type Consorcio } from '../lib/api.js';
+import { createConsorcio, listConsorcios, updateConsorcio, type Consorcio } from '../lib/api.js';
 
 const TIPO_LABEL: Record<Consorcio['tipo'], string> = {
   EDIFICIO: 'Edificio',
@@ -18,6 +18,12 @@ export function ConsorciosPage(): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [showForm, setShowForm] = useState(false);
 
+  // Edición en la propia fila: el caso real es corregir un nombre mal escrito o
+  // la dirección, no llenar un formulario entero de nuevo.
+  const [editando, setEditando] = useState<string | null>(null);
+  const [edNombre, setEdNombre] = useState('');
+  const [edDireccion, setEdDireccion] = useState('');
+
   function load() {
     listConsorcios().then(setItems).catch((e) => setError(e.message));
   }
@@ -32,6 +38,42 @@ export function ConsorciosPage(): JSX.Element {
       setNombre('');
       setDireccion('');
       setShowForm(false);
+      load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function empezarEdicion(c: Consorcio) {
+    setEditando(c.id);
+    setEdNombre(c.nombre);
+    setEdDireccion(c.direccion ?? '');
+    setError(null);
+  }
+
+  async function guardarEdicion(id: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateConsorcio(id, { nombre: edNombre, direccion: edDireccion });
+      setEditando(null);
+      load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function alternarArchivado(c: Consorcio) {
+    setBusy(true);
+    setError(null);
+    try {
+      // Soft-delete: la fila se conserva porque los tickets viejos y su
+      // historial la referencian. Archivado se saca de circulación, no se borra.
+      await updateConsorcio(c.id, { archivado: !c.archivado });
       load();
     } catch (err) {
       setError((err as Error).message);
@@ -82,26 +124,58 @@ export function ConsorciosPage(): JSX.Element {
                 <th>Tipo</th>
                 <th>Dirección</th>
                 <th style={{ width: 100 }}>Estado</th>
+                <th style={{ width: 170 }} />
               </tr>
             </thead>
             <tbody>
               {items.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="muted center">Sin consorcios cargados.</td>
+                  <td colSpan={5} className="muted center">Sin consorcios cargados.</td>
                 </tr>
               )}
               {items.map((c) => (
                 <tr key={c.id}>
                   <td>
-                    <div style={{ fontWeight: 600 }}>{c.nombre}</div>
-                    <div className="mono small muted">#{c.id.slice(0, 8)}</div>
+                    {editando === c.id ? (
+                      <input value={edNombre} onChange={(e) => setEdNombre(e.target.value)} maxLength={140} />
+                    ) : (
+                      <>
+                        <div style={{ fontWeight: 600 }}>{c.nombre}</div>
+                        <div className="mono small muted">#{c.id.slice(0, 8)}</div>
+                      </>
+                    )}
                   </td>
                   <td>{TIPO_LABEL[c.tipo]}</td>
-                  <td className="muted">{c.direccion ?? '—'}</td>
+                  <td className="muted">
+                    {editando === c.id ? (
+                      <input value={edDireccion} onChange={(e) => setEdDireccion(e.target.value)} maxLength={280} placeholder="Dirección" />
+                    ) : (
+                      (c.direccion ?? '—')
+                    )}
+                  </td>
                   <td>
                     {c.archivado
                       ? <span className="chip">Archivado</span>
                       : <span className="chip ok"><span className="dot" />Activo</span>}
+                  </td>
+                  <td>
+                    <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                      {editando === c.id ? (
+                        <>
+                          <button type="button" className="btn primary sm" disabled={busy || !edNombre} onClick={() => guardarEdicion(c.id)}>
+                            Guardar
+                          </button>
+                          <button type="button" className="btn ghost sm" onClick={() => setEditando(null)}>Cancelar</button>
+                        </>
+                      ) : (
+                        <>
+                          <button type="button" className="btn ghost sm" onClick={() => empezarEdicion(c)}>Editar</button>
+                          <button type="button" className="btn ghost sm" disabled={busy} onClick={() => alternarArchivado(c)}>
+                            {c.archivado ? 'Reactivar' : 'Archivar'}
+                          </button>
+                        </>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/apps/admin-web/src/pages/ConsorciosPage.tsx
+++ b/apps/admin-web/src/pages/ConsorciosPage.tsx
@@ -24,8 +24,18 @@ export function ConsorciosPage(): JSX.Element {
   const [edNombre, setEdNombre] = useState('');
   const [edDireccion, setEdDireccion] = useState('');
 
+  // `cargando` no es decorativo: sin él la tabla afirmaba "Sin consorcios
+  // cargados" mientras el pedido estaba en vuelo, y si fallaba mostraba el error
+  // Y ADEMÁS la afirmación de que no hay ninguno. Son tres estados distintos:
+  // no sé todavía, falló, o realmente no hay.
+  const [cargando, setCargando] = useState(true);
+
   function load() {
-    listConsorcios().then(setItems).catch((e) => setError(e.message));
+    setCargando(true);
+    listConsorcios()
+      .then(setItems)
+      .catch((e) => setError(e.message))
+      .finally(() => setCargando(false));
   }
   useEffect(load, []);
 
@@ -130,7 +140,9 @@ export function ConsorciosPage(): JSX.Element {
             <tbody>
               {items.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="muted center">Sin consorcios cargados.</td>
+                  <td colSpan={5} className="muted center">
+                    {cargando ? 'Cargando…' : error ? 'No se pudo cargar la lista.' : 'Sin consorcios cargados.'}
+                  </td>
                 </tr>
               )}
               {items.map((c) => (

--- a/apps/admin-web/src/pages/ConsorciosPage.tsx
+++ b/apps/admin-web/src/pages/ConsorciosPage.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
-import { createConsorcio, listConsorcios, updateConsorcio, type Consorcio } from '../lib/api.js';
+import {
+  avisarConsorciosCambiaron,
+  createConsorcio,
+  listConsorcios,
+  updateConsorcio,
+  type Consorcio,
+} from '../lib/api.js';
 
 const TIPO_LABEL: Record<Consorcio['tipo'], string> = {
   EDIFICIO: 'Edificio',
@@ -49,6 +55,7 @@ export function ConsorciosPage(): JSX.Element {
       setDireccion('');
       setShowForm(false);
       load();
+      avisarConsorciosCambiaron();
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -70,6 +77,7 @@ export function ConsorciosPage(): JSX.Element {
       await updateConsorcio(id, { nombre: edNombre, direccion: edDireccion });
       setEditando(null);
       load();
+      avisarConsorciosCambiaron();
     } catch (err) {
       setError((err as Error).message);
     } finally {
@@ -85,6 +93,7 @@ export function ConsorciosPage(): JSX.Element {
       // historial la referencian. Archivado se saca de circulación, no se borra.
       await updateConsorcio(c.id, { archivado: !c.archivado });
       load();
+      avisarConsorciosCambiaron();
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/apps/admin-web/src/pages/LoginPage.tsx
+++ b/apps/admin-web/src/pages/LoginPage.tsx
@@ -21,6 +21,12 @@ const DEMO = import.meta.env.DEV
     ]
   : [];
 
+/**
+ * Rutas que solo puede usar el SUPER_ADMIN. Si el login viene con un `from` que
+ * apunta a una de ellas y quien entra no lo es, se lo lleva al inicio.
+ */
+const SOLO_SUPER_ADMIN = ['/administraciones'];
+
 export function LoginPage(): JSX.Element {
   const { setSession } = useAuth();
   const nav = useNavigate();
@@ -39,8 +45,15 @@ export function LoginPage(): JSX.Element {
       const r = await login(email.trim(), password);
       setToken(r.accessToken);
       setSession(r.user);
+      // `from` es la ruta a la que el usuario quería entrar antes de que el
+      // guard lo mandara al login. Restaurarla es correcto cuando se vence la
+      // sesión y la persona vuelve a entrar, pero **cruza identidades**: si
+      // venías de /administraciones como super admin y ahora entrás como
+      // administradora, te devolvía a una página que tu rol no puede usar y lo
+      // primero que veías era el cartel rojo de "esta sección no te corresponde".
       const from = (loc.state as { from?: string } | null)?.from ?? '/';
-      nav(from, { replace: true });
+      const permitida = !SOLO_SUPER_ADMIN.some((ruta) => from.startsWith(ruta)) || r.user.kind === 'SUPER_ADMIN';
+      nav(permitida ? from : '/', { replace: true });
     } catch (err) {
       setError((err as Error).message || 'No se pudo iniciar sesión');
     } finally {

--- a/apps/admin-web/src/pages/LoginPage.tsx
+++ b/apps/admin-web/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { login, setToken } from '../lib/api.js';
+import { login, setRefreshToken, setToken } from '../lib/api.js';
 import { useAuth } from '../lib/auth-ctx.js';
 
 /**
@@ -44,6 +44,9 @@ export function LoginPage(): JSX.Element {
     try {
       const r = await login(email.trim(), password);
       setToken(r.accessToken);
+      // El refresh se guardaba en ninguna parte: la respuesta lo trae y se
+      // descartaba, así que la sesión no se podía renovar y moría a los 15 min.
+      setRefreshToken(r.refreshToken);
       setSession(r.user);
       // `from` es la ruta a la que el usuario quería entrar antes de que el
       // guard lo mandara al login. Restaurarla es correcto cuando se vence la

--- a/apps/admin-web/src/pages/LoginPage.tsx
+++ b/apps/admin-web/src/pages/LoginPage.tsx
@@ -3,19 +3,31 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { login, setToken } from '../lib/api.js';
 import { useAuth } from '../lib/auth-ctx.js';
 
-const DEMO = [
-  { email: 'admin@consorciofix.dev', pwd: 'admin123', label: 'Administradora' },
-  { email: 'super@consorciofix.dev', pwd: 'super123', label: 'Super admin' },
-  { email: 'propi@consorciofix.dev', pwd: 'resi123', label: 'Propietaria 4A' },
-  { email: 'inqui@consorciofix.dev', pwd: 'resi123', label: 'Inquilina 4A' },
-];
+/**
+ * Atajos para las cuentas del seed. Sirven muchísimo para desarrollar y para la
+ * demo de la defensa, pero son credenciales reales del entorno de desarrollo:
+ * si el panel se publica, quedan en texto plano dentro del bundle de JS que
+ * cualquiera puede leer, apuntando a usuarios que el seed crea de verdad.
+ *
+ * `import.meta.env.DEV` es false en el build de producción, así que Vite elimina
+ * la lista entera del bundle en vez de solo esconder los botones.
+ */
+const DEMO = import.meta.env.DEV
+  ? [
+      { email: 'admin@consorciofix.dev', pwd: 'admin123', label: 'Administradora' },
+      { email: 'super@consorciofix.dev', pwd: 'super123', label: 'Super admin' },
+      { email: 'propi@consorciofix.dev', pwd: 'resi123', label: 'Propietaria 4A' },
+      { email: 'inqui@consorciofix.dev', pwd: 'resi123', label: 'Inquilina 4A' },
+    ]
+  : [];
 
 export function LoginPage(): JSX.Element {
   const { setSession } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
-  const [email, setEmail] = useState('admin@consorciofix.dev');
-  const [password, setPassword] = useState('admin123');
+  // Precargado solo en desarrollo: en producción el formulario arranca vacío.
+  const [email, setEmail] = useState(DEMO[0]?.email ?? '');
+  const [password, setPassword] = useState(DEMO[0]?.pwd ?? '');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -71,6 +83,7 @@ export function LoginPage(): JSX.Element {
         <button type="submit" className="btn primary" disabled={loading} style={{ width: '100%' }}>
           {loading ? 'Entrando…' : 'Entrar'}
         </button>
+        {DEMO.length > 0 && (
         <div className="mt-2" style={{ borderTop: '1px solid var(--cf-line)', paddingTop: 12 }}>
           <div className="uppercase" style={{ marginBottom: 6 }}>Cuentas demo</div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -91,6 +104,7 @@ export function LoginPage(): JSX.Element {
             ))}
           </div>
         </div>
+        )}
       </form>
     </div>
   );

--- a/apps/admin-web/src/pages/MetricsPage.tsx
+++ b/apps/admin-web/src/pages/MetricsPage.tsx
@@ -74,7 +74,8 @@ export function MetricsPage(): JSX.Element {
 
   return (
     <>
-      <Topbar title="Resumen" subtitle="Métricas operativas del tenant" />
+      {/* "del tenant" era jerga del código: quien lee esto es la administradora. */}
+      <Topbar title="Resumen" subtitle="Métricas operativas de tu administración" />
       <div className="content">
         <section className="stack">
           <div className="filters-bar" style={{ padding: '0 0 12px', borderBottom: 'none' }}>

--- a/apps/admin-web/src/pages/MetricsPage.tsx
+++ b/apps/admin-web/src/pages/MetricsPage.tsx
@@ -168,6 +168,59 @@ export function MetricsPage(): JSX.Element {
                 </div>
               </div>
 
+              {/* RF-C07: costo del clasificador. La API lo calculaba desde la
+                  migración 0006 y no había ninguna pantalla que lo mostrara,
+                  así que el dato con el que se decide si el precio del SaaS
+                  cierra existía solo en la base. */}
+              <div className="card">
+                <div className="row-between" style={{ marginBottom: 12 }}>
+                  <div className="uppercase">Costo de la IA</div>
+                  <span className="muted small">
+                    {data.costoIa.ticketsClasificados} ticket{data.costoIa.ticketsClasificados === 1 ? '' : 's'} clasificado{data.costoIa.ticketsClasificados === 1 ? '' : 's'}
+                  </span>
+                </div>
+                {data.costoIa.ticketsClasificados === 0 ? (
+                  <div className="muted small">
+                    Todavía no se clasificó ningún ticket en este consorcio. Con el proveedor en
+                    modo mock el costo es cero por definición.
+                  </div>
+                ) : (
+                  <>
+                    <div className="kpi-strip">
+                      <div className="kpi">
+                        <div className="kpi-label">Costo total</div>
+                        <div className="kpi-value">US$ {data.costoIa.totalUsd.toFixed(4)}</div>
+                        <div className="kpi-delta">acumulado</div>
+                      </div>
+                      <div className="kpi">
+                        <div className="kpi-label">Por ticket</div>
+                        <div className="kpi-value">US$ {data.costoIa.promedioPorTicketUsd.toFixed(6)}</div>
+                        <div className="kpi-delta">promedio</div>
+                      </div>
+                      <div className="kpi">
+                        <div className="kpi-label">Latencia mediana</div>
+                        <div className="kpi-value">{data.costoIa.latenciaP50Ms} ms</div>
+                        <div className="kpi-delta">p50 del clasificador</div>
+                      </div>
+                      <div className="kpi">
+                        <div className="kpi-label">Corregidos por el admin</div>
+                        <div className="kpi-value">{data.costoIa.corregidosPorAdmin}</div>
+                        <div className="kpi-delta">
+                          {data.costoIa.ticketsClasificados > 0
+                            ? `${Math.round((data.costoIa.corregidosPorAdmin / data.costoIa.ticketsClasificados) * 100)}% de tasa de error`
+                            : '—'}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="muted small mt-3">
+                      Tokens: <span className="mono">{data.costoIa.tokensIn.toLocaleString('es-AR')}</span> de entrada ·{' '}
+                      <span className="mono">{data.costoIa.tokensOut.toLocaleString('es-AR')}</span> de salida. Cada
+                      corrección del admin alimenta el dataset de evaluación del clasificador.
+                    </div>
+                  </>
+                )}
+              </div>
+
               <div className="card">
                 <div className="uppercase" style={{ marginBottom: 12 }}>Gastos confirmados</div>
                 {data.costosConfirmados.length === 0 ? (

--- a/apps/admin-web/src/pages/MetricsPage.tsx
+++ b/apps/admin-web/src/pages/MetricsPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Topbar } from '../components/Shell.js';
 import {
+  EVENTO_CONSORCIO_ACTIVO,
+  getConsorcioActivo,
   getMetrics,
   listConsorcios,
+  setConsorcioActivo,
   type Consorcio,
   type MetricsOverview,
   type TicketEstado,
@@ -39,7 +42,13 @@ const ESTADO_CHIP: Record<TicketEstado, string> = {
 
 export function MetricsPage(): JSX.Element {
   const [consorcios, setConsorcios] = useState<Consorcio[]>([]);
-  const [consorcioFilter, setConsorcioFilter] = useState<string>('');
+  const [consorcioFilter, setConsorcioFilter] = useState<string>(getConsorcioActivo() ?? '');
+
+  useEffect(() => {
+    const sincronizar = () => setConsorcioFilter(getConsorcioActivo() ?? '');
+    window.addEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+    return () => window.removeEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+  }, []);
   const [data, setData] = useState<MetricsOverview | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -81,7 +90,7 @@ export function MetricsPage(): JSX.Element {
           <div className="filters-bar" style={{ padding: '0 0 12px', borderBottom: 'none' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <span className="uppercase">Consorcio</span>
-              <select value={consorcioFilter} onChange={(e) => setConsorcioFilter(e.target.value)} style={{ minWidth: 240, height: 32 }}>
+              <select value={consorcioFilter} onChange={(e) => setConsorcioActivo(e.target.value)} style={{ minWidth: 240, height: 32 }}>
                 <option value="">Todos</option>
                 {consorcios.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
               </select>

--- a/apps/admin-web/src/pages/MetricsPage.tsx
+++ b/apps/admin-web/src/pages/MetricsPage.tsx
@@ -95,7 +95,9 @@ export function MetricsPage(): JSX.Element {
                 <div className="kpi">
                   <div className="kpi-label">Tickets totales</div>
                   <div className="kpi-value">{totalTickets}</div>
-                  <div className="kpi-delta">en este consorcio</div>
+                  <div className="kpi-delta">
+                    {consorcioFilter ? 'en este consorcio' : 'en toda la administración'}
+                  </div>
                 </div>
                 <div className="kpi">
                   <div className="kpi-label">Tiempo medio resol.</div>

--- a/apps/admin-web/src/pages/NotificationsPage.tsx
+++ b/apps/admin-web/src/pages/NotificationsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
 import { Topbar } from '../components/Shell.js';
 import { listNotifs, type NotifEntry } from '../lib/api.js';
 
@@ -34,15 +35,20 @@ export function NotificationsPage(): JSX.Element {
   const [items, setItems] = useState<NotifEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // `?ticket=` llega desde el detalle del ticket. La API ya aceptaba el filtro
+  // y esta pantalla lo ignoraba, así que el admin tenía que buscar a ojo entre
+  // todos los envíos del tenant.
+  const [params, setParams] = useSearchParams();
+  const ticketFiltro = params.get('ticket') ?? '';
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    listNotifs()
+    listNotifs(ticketFiltro ? { ticket_id: ticketFiltro } : {})
       .then(setItems)
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, []);
+  }, [ticketFiltro]);
 
   const sent = items.filter((i) => i.estado === 'ENVIADA').length;
   const failed = items.filter((i) => i.estado === 'FALLIDA').length;
@@ -52,6 +58,21 @@ export function NotificationsPage(): JSX.Element {
     <>
       <Topbar title="Notificaciones" subtitle="Historial de envíos a vecinos (RF-G01..G03)" />
       <div className="content">
+        {ticketFiltro && (
+          <section style={{ paddingBottom: 0 }}>
+            <div className="row-between card tight">
+              <span className="small">
+                Filtrando los avisos del ticket <span className="mono">#{ticketFiltro.slice(0, 8)}</span>
+              </span>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <Link className="btn ghost sm" to={`/tickets/${ticketFiltro}`}>Ver ticket</Link>
+                <button type="button" className="btn ghost sm" onClick={() => setParams({})}>
+                  Ver todos
+                </button>
+              </div>
+            </div>
+          </section>
+        )}
         <section style={{ paddingBottom: 0 }}>
           <div className="kpi-strip">
             <div className="kpi">

--- a/apps/admin-web/src/pages/ResidentesPage.tsx
+++ b/apps/admin-web/src/pages/ResidentesPage.tsx
@@ -32,8 +32,16 @@ export function ResidentesPage(): JSX.Element {
   const [crearUnidades, setCrearUnidades] = useState(true);
   const [informe, setInforme] = useState<ResultadoImport | null>(null);
 
+  // Mismo criterio que en Consorcios: "sin vecinos" solo se afirma cuando se
+  // sabe. Antes se afirmaba durante la carga y también cuando el pedido fallaba.
+  const [cargando, setCargando] = useState(true);
+
   function load() {
-    listResidentes().then(setItems).catch((e) => setError(e.message));
+    setCargando(true);
+    listResidentes()
+      .then(setItems)
+      .catch((e) => setError(e.message))
+      .finally(() => setCargando(false));
   }
   useEffect(load, []);
   useEffect(() => {
@@ -270,7 +278,11 @@ export function ResidentesPage(): JSX.Element {
             </thead>
             <tbody>
               {items.length === 0 && (
-                <tr><td colSpan={4} className="muted center">Sin vecinos cargados.</td></tr>
+                <tr>
+                  <td colSpan={4} className="muted center">
+                    {cargando ? 'Cargando…' : error ? 'No se pudo cargar la lista.' : 'Sin vecinos cargados.'}
+                  </td>
+                </tr>
               )}
               {items.map((r) => (
                 <tr key={r.id}>

--- a/apps/admin-web/src/pages/ResidentesPage.tsx
+++ b/apps/admin-web/src/pages/ResidentesPage.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
-import { createResidente, listResidentes, type Residente } from '../lib/api.js';
+import {
+  createResidente,
+  importarResidentes,
+  listConsorcios,
+  listResidentes,
+  type Consorcio,
+  type Residente,
+  type ResultadoImport,
+} from '../lib/api.js';
 
 export function ResidentesPage(): JSX.Element {
   const [items, setItems] = useState<Residente[]>([]);
@@ -13,10 +21,56 @@ export function ResidentesPage(): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [showForm, setShowForm] = useState(false);
 
+  // Importación masiva (RF-A05). El endpoint existía desde el PR #38 y no había
+  // ninguna pantalla que lo llamara: cargar un consorcio de 80 unidades había
+  // que hacerlo de a un vecino por vez.
+  const [showImport, setShowImport] = useState(false);
+  const [consorcios, setConsorcios] = useState<Consorcio[]>([]);
+  const [impConsorcio, setImpConsorcio] = useState('');
+  const [csv, setCsv] = useState('');
+  const [nombreArchivo, setNombreArchivo] = useState('');
+  const [crearUnidades, setCrearUnidades] = useState(true);
+  const [informe, setInforme] = useState<ResultadoImport | null>(null);
+
   function load() {
     listResidentes().then(setItems).catch((e) => setError(e.message));
   }
   useEffect(load, []);
+  useEffect(() => {
+    listConsorcios().then(setConsorcios).catch(() => setConsorcios([]));
+  }, []);
+
+  function onElegirArchivo(e: ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setNombreArchivo(f.name);
+    setInforme(null);
+    const reader = new FileReader();
+    // Se lee acá y se manda como texto: la API recibe el CSV en el body, así
+    // que no hace falta multipart ni multer del otro lado.
+    reader.onload = () => setCsv(String(reader.result ?? ''));
+    reader.onerror = () => setError('No pude leer el archivo.');
+    reader.readAsText(f, 'utf-8');
+  }
+
+  async function correrImport(dryRun: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      const r = await importarResidentes({
+        consorcio_id: impConsorcio,
+        csv,
+        dry_run: dryRun,
+        crear_unidades: crearUnidades,
+      });
+      setInforme(r);
+      if (!dryRun) load();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function onCreate(e: FormEvent) {
     e.preventDefault();
@@ -48,13 +102,139 @@ export function ResidentesPage(): JSX.Element {
         title="Vecinos"
         subtitle={`${items.length} ${items.length === 1 ? 'residente registrado' : 'residentes registrados'}`}
         actions={
-          <button type="button" className="btn primary" onClick={() => setShowForm((s) => !s)}>
-            <Icons.plus size={14} sw={2.2} /> {showForm ? 'Cancelar' : 'Nuevo vecino'}
-          </button>
+          <>
+            <button type="button" className="btn ghost" onClick={() => setShowImport((s) => !s)}>
+              <Icons.filter size={14} /> {showImport ? 'Cerrar importación' : 'Importar CSV'}
+            </button>
+            <button type="button" className="btn primary" onClick={() => setShowForm((s) => !s)}>
+              <Icons.plus size={14} sw={2.2} /> {showForm ? 'Cancelar' : 'Nuevo vecino'}
+            </button>
+          </>
         }
       />
       <div className="content">
         <section className="stack">
+          {showImport && (
+            <div className="card form-grid">
+              <div style={{ fontSize: 13, fontWeight: 600 }}>Importar vecinos desde una planilla</div>
+              <div className="muted small">
+                Columnas aceptadas: <span className="mono">nombre, telefono, email, unidad, rol</span>.
+                Acepta alias comunes (celular o whatsapp por telefono; depto o lote por unidad;
+                vinculo o tipo por rol) y no distingue acentos ni mayúsculas.
+              </div>
+              <label>
+                <span>Consorcio destino</span>
+                <select value={impConsorcio} onChange={(e) => setImpConsorcio(e.target.value)} required>
+                  <option value="">Elegí un consorcio…</option>
+                  {consorcios.map((c) => (
+                    <option key={c.id} value={c.id}>{c.nombre}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>Archivo CSV</span>
+                <input type="file" accept=".csv,text/csv" onChange={onElegirArchivo} />
+              </label>
+              {nombreArchivo && (
+                <div className="muted small">
+                  {nombreArchivo} · {csv.split('\n').filter((l) => l.trim()).length} líneas leídas
+                </div>
+              )}
+              <label style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                <input type="checkbox" checked={crearUnidades} onChange={(e) => setCrearUnidades(e.target.checked)} />
+                <span>Crear las unidades que no existan</span>
+              </label>
+              <div className="actions">
+                {/* Primero se prueba, después se aplica: en una planilla de 200
+                    filas conviene ver el informe antes de escribir nada. */}
+                <button type="button" className="btn ghost" disabled={busy || !csv || !impConsorcio} onClick={() => correrImport(true)}>
+                  Probar sin guardar
+                </button>
+                <button type="button" className="btn primary" disabled={busy || !csv || !impConsorcio} onClick={() => correrImport(false)}>
+                  {busy ? 'Procesando…' : 'Importar de verdad'}
+                </button>
+              </div>
+
+              {informe && (
+                <div className="card tight">
+                  <div className="row-between">
+                    <strong style={{ fontSize: 13 }}>
+                      {informe.dryRun ? 'Prueba (no se guardó nada)' : 'Importación aplicada'}
+                    </strong>
+                    <span className="muted small">{informe.totalFilas} filas en el archivo</span>
+                  </div>
+                  <div className="kpi-strip mt-3">
+                    <div className="kpi">
+                      <div className="kpi-label">Vecinos nuevos</div>
+                      <div className="kpi-value">{informe.insertadas}</div>
+                    </div>
+                    <div className="kpi">
+                      <div className="kpi-label">Vínculos creados</div>
+                      <div className="kpi-value">{informe.vinculosCreados}</div>
+                    </div>
+                    <div className="kpi">
+                      <div className="kpi-label">Ya existían</div>
+                      <div className="kpi-value">{informe.vinculosYaExistentes}</div>
+                    </div>
+                    <div className="kpi">
+                      <div className="kpi-label">Con error</div>
+                      <div className="kpi-value">{informe.errores.length}</div>
+                    </div>
+                  </div>
+
+                  {informe.unidadesCreadas.length > 0 && (
+                    <div className="muted small mt-3">
+                      Unidades creadas: {informe.unidadesCreadas.join(', ')}
+                    </div>
+                  )}
+
+                  {informe.reusados.length > 0 && (
+                    <div className="mt-3">
+                      <div className="uppercase">Vecinos que ya existían por teléfono</div>
+                      <div className="muted small">
+                        Se reusó el registro existente. El nombre del archivo NO se aplicó.
+                      </div>
+                      <table className="grid mt-2">
+                        <thead>
+                          <tr><th>Fila</th><th>Teléfono</th><th>En el archivo</th><th>En el sistema</th></tr>
+                        </thead>
+                        <tbody>
+                          {informe.reusados.map((r) => (
+                            <tr key={`${r.fila}-${r.telefono}`}>
+                              <td className="mono">{r.fila}</td>
+                              <td className="mono">{r.telefono}</td>
+                              <td>{r.nombreEnArchivo}</td>
+                              <td>{r.nombreExistente}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+
+                  {informe.errores.length > 0 && (
+                    <div className="mt-3">
+                      <div className="uppercase">Filas rechazadas</div>
+                      <table className="grid mt-2">
+                        <thead>
+                          <tr><th>Fila</th><th>Motivo</th><th>Datos</th></tr>
+                        </thead>
+                        <tbody>
+                          {informe.errores.map((er) => (
+                            <tr key={`${er.fila}-${er.motivo}`}>
+                              <td className="mono">{er.fila}</td>
+                              <td>{er.motivo}</td>
+                              <td className="muted small">{Object.values(er.datos).filter(Boolean).join(' · ')}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
           {showForm && (
             <form className="card form-grid" onSubmit={onCreate}>
               <label>

--- a/apps/admin-web/src/pages/ResidentesPage.tsx
+++ b/apps/admin-web/src/pages/ResidentesPage.tsx
@@ -124,8 +124,8 @@ export function ResidentesPage(): JSX.Element {
         <section className="stack">
           {showImport && (
             <div className="card form-grid">
-              <div style={{ fontSize: 13, fontWeight: 600 }}>Importar vecinos desde una planilla</div>
-              <div className="muted small">
+              <div className="form-full" style={{ fontSize: 13, fontWeight: 600 }}>Importar vecinos desde una planilla</div>
+              <div className="form-full muted small">
                 Columnas aceptadas: <span className="mono">nombre, telefono, email, unidad, rol</span>.
                 Acepta alias comunes (celular o whatsapp por telefono; depto o lote por unidad;
                 vinculo o tipo por rol) y no distingue acentos ni mayúsculas.
@@ -148,11 +148,11 @@ export function ResidentesPage(): JSX.Element {
                   {nombreArchivo} · {csv.split('\n').filter((l) => l.trim()).length} líneas leídas
                 </div>
               )}
-              <label style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+              <label className="form-full" style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
                 <input type="checkbox" checked={crearUnidades} onChange={(e) => setCrearUnidades(e.target.checked)} />
                 <span>Crear las unidades que no existan</span>
               </label>
-              <div className="actions">
+              <div className="form-full actions">
                 {/* Primero se prueba, después se aplica: en una planilla de 200
                     filas conviene ver el informe antes de escribir nada. */}
                 <button type="button" className="btn ghost" disabled={busy || !csv || !impConsorcio} onClick={() => correrImport(true)}>
@@ -164,7 +164,7 @@ export function ResidentesPage(): JSX.Element {
               </div>
 
               {informe && (
-                <div className="card tight">
+                <div className="form-full card tight">
                   <div className="row-between">
                     <strong style={{ fontSize: 13 }}>
                       {informe.dryRun ? 'Prueba (no se guardó nada)' : 'Importación aplicada'}

--- a/apps/admin-web/src/pages/TicketDetailPage.tsx
+++ b/apps/admin-web/src/pages/TicketDetailPage.tsx
@@ -755,7 +755,11 @@ export function TicketDetailPage(): JSX.Element {
               <dl className="meta-list mt-3">
                 <dt>Consorcio</dt>
                 <dd className="small">{cons?.nombre ?? <span className="mono">{ticket.consorcioId.slice(0, 8)}</span>}</dd>
-                <dt>Unidad</dt>
+                {/* En un ticket de espacio común, `unidad_id` es la unidad de
+                    QUIEN REPORTÓ —el bot imputa la del vecino que escribe—, no
+                    dónde está el problema. Etiquetarla "Unidad" a secas invitaba a
+                    leer que el SUM sucio era de la 1B. */}
+                <dt>{ticket.origen === 'ESPACIO_COMUN' ? 'Reportó desde' : 'Unidad'}</dt>
                 <dd className="small">{etiquetaDe(ticket.unidadId)}</dd>
                 <dt>Visibilidad</dt>
                 <dd>

--- a/apps/admin-web/src/pages/TicketDetailPage.tsx
+++ b/apps/admin-web/src/pages/TicketDetailPage.tsx
@@ -4,14 +4,20 @@ import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
   createGasto,
+  getHistorial,
   getTicket,
+  listCategorias,
   listGastos,
+  listUnidades,
   totalGastos,
   transitionTicket,
+  type Categoria,
   type Gasto,
+  type HistorialEvento,
   type Ticket,
   type TicketEstado,
   type TicketOrigen,
+  type Unidad,
 } from '../lib/api.js';
 
 const ESTADO_LABEL: Record<TicketEstado, string> = {
@@ -49,23 +55,35 @@ export function TicketDetailPage(): JSX.Element {
   const [ticket, setTicket] = useState<Ticket | null>(null);
   const [gastos, setGastos] = useState<Gasto[]>([]);
   const [totales, setTotales] = useState<Array<{ moneda: string; total: number }>>([]);
+  const [historial, setHistorial] = useState<HistorialEvento[]>([]);
+  const [unidades, setUnidades] = useState<Unidad[]>([]);
+  const [categorias, setCategorias] = useState<Categoria[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showValidar, setShowValidar] = useState(false);
   const [origenChoice, setOrigenChoice] = useState<TicketOrigen>('ESPACIO_COMUN');
+  const [unidadReportada, setUnidadReportada] = useState('');
+  const [categoriaChoice, setCategoriaChoice] = useState('');
   const [nota, setNota] = useState('');
   const [showGasto, setShowGasto] = useState(false);
   const [gDesc, setGDesc] = useState('');
   const [gMonto, setGMonto] = useState('');
   const [gComprobante, setGComprobante] = useState('');
+  const [gEstado, setGEstado] = useState<'BORRADOR' | 'CONFIRMADO'>('CONFIRMADO');
 
   const refresh = useCallback(async () => {
     if (!id) return;
     try {
-      const [t, g, tot] = await Promise.all([getTicket(id), listGastos(id), totalGastos(id)]);
+      const [t, g, tot, hist] = await Promise.all([
+        getTicket(id),
+        listGastos(id),
+        totalGastos(id),
+        getHistorial(id),
+      ]);
       setTicket(t);
       setGastos(g);
       setTotales(tot);
+      setHistorial(hist);
     } catch (e) {
       setError((e as Error).message);
     }
@@ -74,6 +92,31 @@ export function TicketDetailPage(): JSX.Element {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Unidades y categorías del consorcio del ticket: se necesitan para validar.
+  // Sin la lista de unidades no se puede elegir la unidad señalada en una
+  // CONDUCTA, y la API rechaza la validación sin ese dato.
+  useEffect(() => {
+    if (!ticket) return;
+    let vigente = true;
+    void (async () => {
+      try {
+        const [us, cs] = await Promise.all([
+          listUnidades(ticket.consorcioId),
+          listCategorias(ticket.consorcioId),
+        ]);
+        if (!vigente) return;
+        setUnidades(us);
+        setCategorias(cs);
+      } catch {
+        // No es fatal: la validación de infraestructura funciona igual. El
+        // selector de conducta avisa por su cuenta si la lista quedó vacía.
+      }
+    })();
+    return () => {
+      vigente = false;
+    };
+  }, [ticket?.consorcioId, ticket]);
 
   if (!id) return <div className="error">Sin id</div>;
 
@@ -107,11 +150,12 @@ export function TicketDetailPage(): JSX.Element {
         monto,
         moneda: 'ARS',
         ...(gComprobante && { comprobante_url: gComprobante }),
-        estado: 'CONFIRMADO',
+        estado: gEstado,
       });
       setGDesc('');
       setGMonto('');
       setGComprobante('');
+      setGEstado('CONFIRMADO');
       setShowGasto(false);
       await refresh();
     } catch (e) {
@@ -132,6 +176,13 @@ export function TicketDetailPage(): JSX.Element {
 
   const totalARS = totales.find((t) => t.moneda === 'ARS')?.total ?? 0;
   const tieneVisibilidad = ticket.origen !== null;
+  const ia = ticket.clasificacion ?? null;
+  const confianzaPct = ia?.confianza != null ? Math.round(ia.confianza * 100) : null;
+  const esConducta = ticket.tipo === 'CONDUCTA';
+  const etiquetaDe = (unidadId: string | null): string => {
+    if (!unidadId) return 'común';
+    return unidades.find((u) => u.id === unidadId)?.etiqueta ?? unidadId.slice(0, 8);
+  };
 
   return (
     <>
@@ -143,9 +194,14 @@ export function TicketDetailPage(): JSX.Element {
           <span style={{ color: 'var(--cf-ink-3)', fontSize: 13 }}>/</span>
           <span style={{ fontSize: 13.5, fontWeight: 600 }}>{ticket.titulo}</span>
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <button type="button" className="btn ghost"><Icons.bell size={14} />Notificar vecinos</button>
-        </div>
+        {/* Acá había un botón "Notificar vecinos" sin handler. No se reemplaza
+            por uno funcional porque el sistema no tiene aviso manual: las
+            notificaciones salen solas en cada transición de estado (RF-G01) y
+            se auditan en Notificaciones. Un botón que promete algo que el
+            sistema no hace es peor que no tenerlo. */}
+        <Link to={`/notificaciones?ticket=${ticket.id}`} className="btn ghost">
+          <Icons.bell size={14} />Ver avisos enviados
+        </Link>
       </div>
 
       <div className="content">
@@ -158,27 +214,54 @@ export function TicketDetailPage(): JSX.Element {
                 <div style={{ flex: 1 }}>
                   <div className="ai-panel-title">Sugerencia de la IA</div>
                   <div style={{ fontSize: 11.5, color: 'var(--cf-ink-3)' }}>
-                    Texto · {ticket.tipo === 'CONDUCTA' ? 'reporte de conducta' : 'reporte de infraestructura'}
+                    {ia
+                      ? `${ia.modelo} · prompt ${ia.promptVersion}`
+                      : 'Cargado a mano por la administración — sin clasificar'}
                   </div>
                 </div>
-                <span className="chip blue"><span className="mono">85%</span> confianza</span>
+                {/* La confianza sale de `clasificacion_ia`. Antes había un 85%
+                    fijo escrito en el código: el admin decidía mirando un
+                    número inventado. Si no hay clasificación no se muestra
+                    ninguno. */}
+                {confianzaPct !== null && (
+                  <span className={`chip ${confianzaPct >= 80 ? 'blue' : 'med'}`}>
+                    <span className="mono">{confianzaPct}%</span> confianza
+                  </span>
+                )}
+                {ia?.corregidoPorAdmin && (
+                  <span className="chip ok" title="La sugerencia fue corregida al validar">corregida</span>
+                )}
               </div>
               <div className="ai-panel-body">
                 <div className="ai-keyvals">
                   <div>
                     <div className="keyval-k">Categoría sugerida</div>
-                    <div className={`keyval-v ${ticket.origen === 'ESPACIO_COMUN' ? 'common' : ''}`}>
-                      {ticket.tipo === 'CONDUCTA'
-                        ? 'Conducta'
-                        : ticket.origen === 'ESPACIO_COMUN'
-                          ? 'Espacio Común'
-                          : ticket.origen === 'UNIDAD'
-                            ? 'Unidad Privada'
-                            : 'Sin validar'}
+                    <div className="keyval-v">
+                      {ia?.sugerido.categoria ?? <span className="muted">—</span>}
                     </div>
                   </div>
                   <div>
-                    <div className="keyval-k">Urgencia</div>
+                    <div className="keyval-k">Tipo sugerido</div>
+                    <div className="keyval-v">
+                      {ia?.sugerido.tipo === 'CONDUCTA'
+                        ? 'Conducta'
+                        : ia?.sugerido.tipo === 'INFRAESTRUCTURA'
+                          ? 'Infraestructura'
+                          : <span className="muted">—</span>}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="keyval-k">Origen sugerido</div>
+                    <div className={`keyval-v ${ia?.sugerido.origen === 'ESPACIO_COMUN' ? 'common' : ''}`}>
+                      {ia?.sugerido.origen === 'ESPACIO_COMUN'
+                        ? 'Espacio común'
+                        : ia?.sugerido.origen === 'UNIDAD'
+                          ? 'Unidad privada'
+                          : <span className="muted">—</span>}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="keyval-k">Urgencia (vigente)</div>
                     <div className={`keyval-v ${URGENCIA_CLS[ticket.urgencia]}`}>
                       {URGENCIA_LABEL[ticket.urgencia]}
                     </div>
@@ -188,9 +271,30 @@ export function TicketDetailPage(): JSX.Element {
                     <div className="keyval-v">{ESTADO_LABEL[ticket.estado]}</div>
                   </div>
                 </div>
+
+                {/* RF-F01: la unidad que el modelo dedujo del texto NO se imputa
+                    sola. Se muestra como pista para que el admin la confirme
+                    contra la lista real de unidades. */}
+                {ia?.sugerido.unidad_reportada_texto && (
+                  <div className="muted small mt-2">
+                    El vecino mencionó: “{ia.sugerido.unidad_reportada_texto}”. Confirmá la unidad al validar.
+                  </div>
+                )}
+
                 <div className="ai-summary">
                   <b style={{ color: 'var(--cf-ink)' }}>Descripción:</b> {ticket.descripcionNormalizada}
                 </div>
+
+                {/* RF-C07: lo que costó clasificar este ticket. Se persistía en
+                    la base y no se mostraba en ninguna pantalla. */}
+                {ia && (ia.costoUsd || ia.latenciaMs || ia.tokensIn) && (
+                  <div className="muted small mt-2" style={{ display: 'flex', gap: 14, flexWrap: 'wrap' }}>
+                    {ia.costoUsd && <span>Costo IA: <span className="mono">US$ {Number(ia.costoUsd).toFixed(6)}</span></span>}
+                    {ia.tokensIn !== null && <span>Tokens: <span className="mono">{ia.tokensIn}→{ia.tokensOut ?? 0}</span></span>}
+                    {ia.latenciaMs !== null && <span>Latencia: <span className="mono">{ia.latenciaMs} ms</span></span>}
+                    {ia.cacheHit && <span>cache hit</span>}
+                  </div>
+                )}
 
                 {ticket.estado === 'REGISTRADO' && (
                   <div className="actions mt-4">
@@ -210,11 +314,68 @@ export function TicketDetailPage(): JSX.Element {
                       </>
                     ) : (
                       <div className="card tight" style={{ width: '100%' }}>
-                        <div className="uppercase mt-2">Origen (afecta visibilidad)</div>
-                        <div className="segment mt-2">
-                          <button type="button" className={origenChoice === 'ESPACIO_COMUN' ? 'on' : ''} onClick={() => setOrigenChoice('ESPACIO_COMUN')}>Espacio común</button>
-                          <button type="button" className={origenChoice === 'UNIDAD' ? 'on' : ''} onClick={() => setOrigenChoice('UNIDAD')}>Unidad</button>
-                        </div>
+                        {esConducta ? (
+                          <>
+                            {/* RF-F01: sin esto la validación de una conducta es
+                                imposible. La API la exige (y hay un CHECK en la
+                                base que la respalda), así que el botón fallaba
+                                siempre: el circuito entero de conducta quedaba
+                                inalcanzable desde el panel. */}
+                            <div className="uppercase mt-2">Unidad señalada (obligatoria)</div>
+                            <div className="muted small mt-2">
+                              Es la unidad del vecino denunciado. Define quién ve el ticket, así que
+                              conviene confirmarla antes de validar.
+                            </div>
+                            <label className="mt-2">
+                              <span>Unidad</span>
+                              <select value={unidadReportada} onChange={(e) => setUnidadReportada(e.target.value)} required>
+                                <option value="">Elegí una unidad…</option>
+                                {unidades.map((u) => (
+                                  <option key={u.id} value={u.id}>{u.etiqueta}</option>
+                                ))}
+                              </select>
+                            </label>
+                            {unidades.length === 0 && (
+                              <div className="error small mt-2">
+                                Este consorcio no tiene unidades cargadas. Cargá la unidad del vecino
+                                señalado en Unidades y volvé.
+                              </div>
+                            )}
+                          </>
+                        ) : (
+                          <>
+                            <div className="uppercase mt-2">Origen (afecta visibilidad)</div>
+                            <div className="segment mt-2">
+                              <button type="button" className={origenChoice === 'ESPACIO_COMUN' ? 'on' : ''} onClick={() => setOrigenChoice('ESPACIO_COMUN')}>Espacio común</button>
+                              <button type="button" className={origenChoice === 'UNIDAD' ? 'on' : ''} onClick={() => setOrigenChoice('UNIDAD')}>Unidad</button>
+                            </div>
+                            <div className="muted small mt-2">
+                              {origenChoice === 'ESPACIO_COMUN'
+                                ? 'Lo van a ver todos los residentes del consorcio, con su costo confirmado.'
+                                : 'Lo van a ver solo la administración y los ocupantes de la unidad.'}
+                            </div>
+                          </>
+                        )}
+
+                        {/* La categoría corregida por el admin alimenta el
+                            dataset de RF-C04. El campo existía en la API y
+                            ninguna pantalla lo mandaba, así que la corrección
+                            nunca se registraba. */}
+                        {categorias.length > 0 && (
+                          <label className="mt-3">
+                            <span>
+                              Categoría
+                              {ia?.sugerido.categoria ? ` (la IA sugirió “${ia.sugerido.categoria}”)` : ''}
+                            </span>
+                            <select value={categoriaChoice} onChange={(e) => setCategoriaChoice(e.target.value)}>
+                              <option value="">Sin cambiar</option>
+                              {categorias.map((c) => (
+                                <option key={c.id} value={c.id}>{c.nombre}</option>
+                              ))}
+                            </select>
+                          </label>
+                        )}
+
                         <div className="mt-3">
                           <label>
                             <span>Nota interna</span>
@@ -222,7 +383,19 @@ export function TicketDetailPage(): JSX.Element {
                           </label>
                         </div>
                         <div className="actions mt-3">
-                          <button type="button" className="btn primary" disabled={busy} onClick={() => doTransition('VALIDADO', { origen: origenChoice, ...(nota && { nota }) })}>
+                          <button
+                            type="button"
+                            className="btn primary"
+                            disabled={busy || (esConducta && !unidadReportada)}
+                            onClick={() =>
+                              doTransition('VALIDADO', {
+                                origen: esConducta ? 'UNIDAD' : origenChoice,
+                                ...(esConducta && { unidad_reportada_id: unidadReportada }),
+                                ...(categoriaChoice && { categoria_id: categoriaChoice }),
+                                ...(nota && { nota }),
+                              })
+                            }
+                          >
                             Confirmar validación
                           </button>
                           <button type="button" className="btn ghost" disabled={busy} onClick={() => setShowValidar(false)}>Cancelar</button>
@@ -296,7 +469,20 @@ export function TicketDetailPage(): JSX.Element {
                     <span>URL del comprobante</span>
                     <input type="url" value={gComprobante} onChange={(e) => setGComprobante(e.target.value)} placeholder="https://…" />
                   </label>
-                  <button type="submit" className="btn primary" disabled={busy || !gDesc || !gMonto}>Confirmar gasto</button>
+                  {/* El BORRADOR existía en la API y en la base desde el
+                      principio, y el panel mandaba siempre CONFIRMADO: no había
+                      forma de anotar un presupuesto tentativo sin publicarlo a
+                      los vecinos, que es justamente para qué está el estado. */}
+                  <label>
+                    <span>Estado</span>
+                    <select value={gEstado} onChange={(e) => setGEstado(e.target.value as 'BORRADOR' | 'CONFIRMADO')}>
+                      <option value="CONFIRMADO">Confirmado — visible a los vecinos</option>
+                      <option value="BORRADOR">Borrador — solo la administración</option>
+                    </select>
+                  </label>
+                  <button type="submit" className="btn primary" disabled={busy || !gDesc || !gMonto}>
+                    {gEstado === 'BORRADOR' ? 'Guardar borrador' : 'Confirmar gasto'}
+                  </button>
                 </form>
               )}
 
@@ -308,6 +494,7 @@ export function TicketDetailPage(): JSX.Element {
                     <tr>
                       <th>Descripción</th>
                       <th>Monto</th>
+                      <th>Estado</th>
                       <th>Comprobante</th>
                       <th>Fecha</th>
                     </tr>
@@ -317,12 +504,52 @@ export function TicketDetailPage(): JSX.Element {
                       <tr key={g.id}>
                         <td>{g.descripcion}</td>
                         <td className="mono">{g.moneda} {Number(g.monto).toLocaleString('es-AR', { minimumFractionDigits: 2 })}</td>
+                        <td>
+                          <span className={`chip ${g.estado === 'CONFIRMADO' ? 'ok' : 'med'}`}>
+                            {g.estado === 'CONFIRMADO' ? 'confirmado' : 'borrador'}
+                          </span>
+                        </td>
                         <td>{g.comprobanteUrl ? <a href={g.comprobanteUrl} target="_blank" rel="noreferrer">ver</a> : <span className="muted">—</span>}</td>
                         <td className="muted small">{new Date(g.createdAt).toLocaleString('es-AR')}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
+              )}
+              <div className="muted small mt-2">
+                El total de arriba suma solo los confirmados: es el número que ven los vecinos
+                cuando el ticket es de espacio común.
+              </div>
+            </div>
+
+            {/* Historial auditable (RF-D02). El endpoint existía y ninguna
+                pantalla lo llamaba, así que no había forma de ver quién movió
+                el ticket ni con qué nota. */}
+            <div className="card">
+              <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 12 }}>Historial del ticket</div>
+              {historial.length === 0 ? (
+                <div className="muted small">Sin eventos registrados.</div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  {historial.map((h, i) => (
+                    <div key={`${h.at}-${i}`} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                      <div style={{ flex: 1, lineHeight: 1.35 }}>
+                        <div style={{ fontSize: 13 }}>
+                          {h.estadoAnterior && h.estadoNuevo
+                            ? `${ESTADO_LABEL[h.estadoAnterior]} → ${ESTADO_LABEL[h.estadoNuevo]}`
+                            : h.estadoNuevo
+                              ? `Creado como ${ESTADO_LABEL[h.estadoNuevo]}`
+                              : h.transicion}
+                          {h.autorTipo && (
+                            <span className="muted small"> · {h.autorTipo === 'ADMIN' ? 'administración' : 'residente'}</span>
+                          )}
+                        </div>
+                        {h.nota && <div className="muted small" style={{ marginTop: 2 }}>{h.nota}</div>}
+                      </div>
+                      <span className="muted small" style={{ flexShrink: 0 }}>{shortDate(h.at)}</span>
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           </div>
@@ -373,11 +600,29 @@ export function TicketDetailPage(): JSX.Element {
                 <dt>Consorcio</dt>
                 <dd className="mono small">{ticket.consorcioId.slice(0, 8)}</dd>
                 <dt>Unidad</dt>
-                <dd className="mono small">{ticket.unidadId ? ticket.unidadId.slice(0, 8) : 'común'}</dd>
+                <dd className="small">{etiquetaDe(ticket.unidadId)}</dd>
                 <dt>Visibilidad</dt>
-                <dd>{!tieneVisibilidad ? 'Sin validar' : ticket.origen === 'ESPACIO_COMUN' ? 'Todos los vecinos' : 'Solo ocupantes'}</dd>
+                <dd>
+                  {!tieneVisibilidad
+                    ? 'Sin validar'
+                    : esConducta
+                      ? 'Administración + ocupantes de la unidad señalada'
+                      : ticket.origen === 'ESPACIO_COMUN'
+                        ? 'Todos los vecinos'
+                        : 'Solo ocupantes'}
+                </dd>
                 <dt>Tipo</dt>
-                <dd>{ticket.tipo === 'CONDUCTA' ? 'Conducta (anónimo)' : 'Infraestructura'}</dd>
+                <dd>{esConducta ? 'Conducta (anónimo)' : 'Infraestructura'}</dd>
+                {esConducta && (
+                  <>
+                    <dt>Unidad señalada</dt>
+                    <dd className="small">
+                      {ticket.unidadReportadaId
+                        ? etiquetaDe(ticket.unidadReportadaId)
+                        : <span className="muted">sin confirmar</span>}
+                    </dd>
+                  </>
+                )}
               </dl>
             </div>
           </aside>

--- a/apps/admin-web/src/pages/TicketDetailPage.tsx
+++ b/apps/admin-web/src/pages/TicketDetailPage.tsx
@@ -5,6 +5,7 @@ import { Topbar } from '../components/Shell.js';
 import {
   createGasto,
   createRegistroConducta,
+  getConsorcio,
   getHistorial,
   historialConducta,
   getTicket,
@@ -15,6 +16,7 @@ import {
   totalGastos,
   transitionTicket,
   type Categoria,
+  type Consorcio,
   type EventoConvivencia,
   type RegistroConducta,
   type ResultadoConducta,
@@ -63,6 +65,9 @@ export function TicketDetailPage(): JSX.Element {
   const [totales, setTotales] = useState<Array<{ moneda: string; total: number }>>([]);
   const [historial, setHistorial] = useState<HistorialEvento[]>([]);
   const [unidades, setUnidades] = useState<Unidad[]>([]);
+  // El nombre del consorcio: Metadatos mostraba el UUID recortado, que no le
+  // dice nada a nadie. La unidad ya se resolvía a su etiqueta.
+  const [cons, setCons] = useState<Consorcio | null>(null);
   const [categorias, setCategorias] = useState<Categoria[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -136,13 +141,15 @@ export function TicketDetailPage(): JSX.Element {
     let vigente = true;
     void (async () => {
       try {
-        const [us, cs] = await Promise.all([
+        const [us, cs, c] = await Promise.all([
           listUnidades(ticket.consorcioId),
           listCategorias(ticket.consorcioId),
+          getConsorcio(ticket.consorcioId),
         ]);
         if (!vigente) return;
         setUnidades(us);
         setCategorias(cs);
+        setCons(c);
       } catch {
         // No es fatal: la validación de infraestructura funciona igual. El
         // selector de conducta avisa por su cuenta si la lista quedó vacía.
@@ -161,8 +168,15 @@ export function TicketDetailPage(): JSX.Element {
     setError(null);
     try {
       const payload: Parameters<typeof transitionTicket>[1] = { to, ...(body as object) } as Parameters<typeof transitionTicket>[1];
-      const next = await transitionTicket(ticket.id, payload);
-      setTicket(next);
+      await transitionTicket(ticket.id, payload);
+      // Se recarga en vez de usar la respuesta de la transición: ese endpoint
+      // devuelve la fila del ticket sin `clasificacion` —la sugerencia de la IA
+      // la agrega solo `GET /tickets/:id`—, así que pisar el estado con ella
+      // dejaba el panel de IA en blanco ("sin clasificar") hasta recargar la
+      // página, justo después de la acción que la corrige. Y de paso el
+      // historial gana una fila en cada transición, así que también estaba
+      // quedando viejo.
+      await refresh();
       setShowValidar(false);
       setNota('');
     } catch (e) {
@@ -740,7 +754,7 @@ export function TicketDetailPage(): JSX.Element {
               <div className="uppercase">Metadatos</div>
               <dl className="meta-list mt-3">
                 <dt>Consorcio</dt>
-                <dd className="mono small">{ticket.consorcioId.slice(0, 8)}</dd>
+                <dd className="small">{cons?.nombre ?? <span className="mono">{ticket.consorcioId.slice(0, 8)}</span>}</dd>
                 <dt>Unidad</dt>
                 <dd className="small">{etiquetaDe(ticket.unidadId)}</dd>
                 <dt>Visibilidad</dt>

--- a/apps/admin-web/src/pages/TicketDetailPage.tsx
+++ b/apps/admin-web/src/pages/TicketDetailPage.tsx
@@ -4,14 +4,20 @@ import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
   createGasto,
+  createRegistroConducta,
   getHistorial,
+  historialConducta,
   getTicket,
   listCategorias,
   listGastos,
+  listRegistrosConducta,
   listUnidades,
   totalGastos,
   transitionTicket,
   type Categoria,
+  type EventoConvivencia,
+  type RegistroConducta,
+  type ResultadoConducta,
   type Gasto,
   type HistorialEvento,
   type Ticket,
@@ -71,6 +77,14 @@ export function TicketDetailPage(): JSX.Element {
   const [gComprobante, setGComprobante] = useState('');
   const [gEstado, setGEstado] = useState<'BORRADOR' | 'CONFIRMADO'>('CONFIRMADO');
 
+  // Convivencia (RF-F03): avisos y sanciones del reporte, y el historial de la
+  // unidad señalada. Los endpoints existían y no había ninguna pantalla, así que
+  // el circuito de conducta terminaba en "validado" y no se podía cerrar.
+  const [registros, setRegistros] = useState<RegistroConducta[]>([]);
+  const [convivencia, setConvivencia] = useState<EventoConvivencia[]>([]);
+  const [rcResultado, setRcResultado] = useState<ResultadoConducta>('AVISO');
+  const [rcDetalle, setRcDetalle] = useState('');
+
   const refresh = useCallback(async () => {
     if (!id) return;
     try {
@@ -92,6 +106,27 @@ export function TicketDetailPage(): JSX.Element {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  const refreshConducta = useCallback(async () => {
+    if (!id || !ticket || ticket.tipo !== 'CONDUCTA') return;
+    try {
+      const regs = await listRegistrosConducta(id);
+      setRegistros(regs);
+      // El historial es de la unidad señalada; sin ella todavía no hay a quién
+      // mirarle los antecedentes.
+      if (ticket.unidadReportadaId) {
+        setConvivencia(await historialConducta(ticket.unidadReportadaId));
+      } else {
+        setConvivencia([]);
+      }
+    } catch {
+      // No se corta la pantalla por esto: el resto del ticket se lee igual.
+    }
+  }, [id, ticket]);
+
+  useEffect(() => {
+    void refreshConducta();
+  }, [refreshConducta]);
 
   // Unidades y categorías del consorcio del ticket: se necesitan para validar.
   // Sin la lista de unidades no se puede elegir la unidad señalada en una
@@ -130,6 +165,25 @@ export function TicketDetailPage(): JSX.Element {
       setTicket(next);
       setShowValidar(false);
       setNota('');
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRegistrarConducta(e: FormEvent) {
+    e.preventDefault();
+    if (!ticket) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createRegistroConducta(ticket.id, {
+        resultado: rcResultado,
+        ...(rcDetalle && { detalle: rcDetalle }),
+      });
+      setRcDetalle('');
+      await refreshConducta();
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -521,6 +575,94 @@ export function TicketDetailPage(): JSX.Element {
                 cuando el ticket es de espacio común.
               </div>
             </div>
+
+            {/* Convivencia (RF-F03). Cierra el circuito de una conducta: el
+                admin habla con las partes y deja asentado en qué terminó. Queda
+                registrado contra la unidad SEÑALADA y va a la bitácora. */}
+            {esConducta && (
+              <div className="card">
+                <div className="row-between" style={{ marginBottom: 12 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>Avisos y sanciones</div>
+                  {ticket.unidadReportadaId && (
+                    <span className="muted small">
+                      unidad {etiquetaDe(ticket.unidadReportadaId)} · {convivencia.length} en su historial
+                    </span>
+                  )}
+                </div>
+
+                {!ticket.unidadReportadaId ? (
+                  <div className="muted small">
+                    Validá el ticket indicando la unidad señalada para poder registrar el resultado.
+                  </div>
+                ) : (
+                  <>
+                    {/* Los antecedentes van arriba de la decisión: saber que es la
+                        cuarta vez cambia si corresponde un aviso o una sanción. */}
+                    {convivencia.length > 0 && (
+                      <div className="card tight" style={{ marginBottom: 12 }}>
+                        <div className="uppercase">Antecedentes de la unidad</div>
+                        {convivencia.map((ev) => (
+                          <div key={ev.id} className="row-between" style={{ paddingTop: 6 }}>
+                            <span className="small">
+                              <span className={`chip ${ev.resultado === 'SANCION' ? 'crit' : ev.resultado === 'AVISO' ? 'med' : ''}`}>
+                                {ev.resultado.toLowerCase()}
+                              </span>{' '}
+                              {ev.ticketId === ticket.id ? 'este reporte' : ev.ticketTitulo}
+                            </span>
+                            <span className="muted small">{shortDate(ev.createdAt)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    <form className="form-grid card tight" onSubmit={onRegistrarConducta}>
+                      <label>
+                        <span>En qué terminó</span>
+                        <select value={rcResultado} onChange={(e) => setRcResultado(e.target.value as ResultadoConducta)}>
+                          <option value="AVISO">Aviso a la unidad</option>
+                          <option value="SANCION">Sanción registrada</option>
+                          <option value="DESCARTADO">Se descartó el reporte</option>
+                        </select>
+                      </label>
+                      <label>
+                        <span>Detalle</span>
+                        <textarea
+                          rows={2}
+                          value={rcDetalle}
+                          onChange={(e) => setRcDetalle(e.target.value)}
+                          maxLength={2000}
+                          placeholder="Qué se le dijo, con quién se habló"
+                        />
+                      </label>
+                      <button type="submit" className="btn primary" disabled={busy}>
+                        Registrar
+                      </button>
+                    </form>
+
+                    {registros.length > 0 && (
+                      <table className="grid mt-3">
+                        <thead>
+                          <tr><th>Resultado</th><th>Detalle</th><th style={{ width: 150 }}>Fecha</th></tr>
+                        </thead>
+                        <tbody>
+                          {registros.map((r) => (
+                            <tr key={r.id}>
+                              <td>
+                                <span className={`chip ${r.resultado === 'SANCION' ? 'crit' : r.resultado === 'AVISO' ? 'med' : ''}`}>
+                                  {r.resultado.toLowerCase()}
+                                </span>
+                              </td>
+                              <td>{r.detalle ?? <span className="muted">—</span>}</td>
+                              <td className="muted small">{shortDate(r.createdAt)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
 
             {/* Historial auditable (RF-D02). El endpoint existía y ninguna
                 pantalla lo llamaba, así que no había forma de ver quién movió

--- a/apps/admin-web/src/pages/UnidadesPage.tsx
+++ b/apps/admin-web/src/pages/UnidadesPage.tsx
@@ -4,6 +4,7 @@ import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
   createUnidad,
+  createUnidadesBulk,
   createVinculo,
   desvincular,
   listConsorcios,
@@ -22,6 +23,10 @@ export function UnidadesPage(): JSX.Element {
   const [consorcioId, setConsorcioId] = useState<string>('');
   const [unidades, setUnidades] = useState<Unidad[]>([]);
   const [etiqueta, setEtiqueta] = useState('');
+  // Alta masiva: es como se carga un edificio de verdad, de a 80 unidades.
+  const [modoLote, setModoLote] = useState(false);
+  const [lote, setLote] = useState('');
+  const [info, setInfo] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [showForm, setShowForm] = useState(false);
@@ -56,8 +61,27 @@ export function UnidadesPage(): JSX.Element {
     setBusy(true);
     setError(null);
     try {
-      await createUnidad({ consorcio_id: consorcioId, etiqueta });
-      setEtiqueta('');
+      if (modoLote) {
+        // `POST /unidades/bulk` existía y ninguna pantalla lo usaba: cargar un
+        // edificio de 80 unidades se hacía de a una. Hace onConflictDoNothing,
+        // así que repetir una etiqueta ya cargada no rompe nada.
+        const etiquetas = lote
+          .split(/[\n,;]+/)
+          .map((x) => x.trim())
+          .filter(Boolean);
+        if (etiquetas.length === 0) throw new Error('No hay etiquetas para crear.');
+        const creadas = await createUnidadesBulk({ consorcio_id: consorcioId, etiquetas });
+        const repetidas = etiquetas.length - creadas.length;
+        setInfo(
+          `Se crearon ${creadas.length} de ${etiquetas.length}.` +
+            (repetidas > 0 ? ` ${repetidas} ya existían y se dejaron como estaban.` : ''),
+        );
+        setLote('');
+      } else {
+        await createUnidad({ consorcio_id: consorcioId, etiqueta });
+        setEtiqueta('');
+        setInfo(null);
+      }
       setShowForm(false);
       load();
     } catch (err) {
@@ -91,14 +115,37 @@ export function UnidadesPage(): JSX.Element {
 
           {showForm && (
             <form className="card form-grid" onSubmit={onCreate}>
-              <label>
-                <span>Etiqueta</span>
-                <input value={etiqueta} onChange={(e) => setEtiqueta(e.target.value)} required maxLength={40} placeholder="Ej. 4A o Lote 12" />
-              </label>
-              <button type="submit" className="btn primary" disabled={busy || !consorcioId || !etiqueta}>Crear unidad</button>
+              <div className="segment">
+                <button type="button" className={!modoLote ? 'on' : ''} onClick={() => setModoLote(false)}>Una unidad</button>
+                <button type="button" className={modoLote ? 'on' : ''} onClick={() => setModoLote(true)}>Varias de una vez</button>
+              </div>
+              {modoLote ? (
+                <label>
+                  <span>Etiquetas (una por línea, o separadas por coma)</span>
+                  <textarea
+                    rows={6}
+                    value={lote}
+                    onChange={(e) => setLote(e.target.value)}
+                    placeholder={'1A\n1B\n2A\n2B'}
+                  />
+                </label>
+              ) : (
+                <label>
+                  <span>Etiqueta</span>
+                  <input value={etiqueta} onChange={(e) => setEtiqueta(e.target.value)} maxLength={40} placeholder="Ej. 4A o Lote 12" />
+                </label>
+              )}
+              <button
+                type="submit"
+                className="btn primary"
+                disabled={busy || !consorcioId || (modoLote ? !lote.trim() : !etiqueta)}
+              >
+                {modoLote ? 'Crear las unidades' : 'Crear unidad'}
+              </button>
             </form>
           )}
 
+          {info && <div className="chip ok">{info}</div>}
           {error && <div className="error">{error}</div>}
 
           <table className="grid">

--- a/apps/admin-web/src/pages/UnidadesPage.tsx
+++ b/apps/admin-web/src/pages/UnidadesPage.tsx
@@ -47,11 +47,17 @@ export function UnidadesPage(): JSX.Element {
       .catch((e) => setError(e.message));
   }, [searchParams]);
 
+  // Acá además hay un caso propio: sin consorcio elegido no hay nada que cargar,
+  // y eso tampoco es "sin unidades".
+  const [cargando, setCargando] = useState(false);
+
   function load() {
     if (!consorcioId) return;
+    setCargando(true);
     listUnidades(consorcioId)
       .then(setUnidades)
-      .catch((e) => setError(e.message));
+      .catch((e) => setError(e.message))
+      .finally(() => setCargando(false));
   }
   useEffect(load, [consorcioId]);
 
@@ -158,7 +164,17 @@ export function UnidadesPage(): JSX.Element {
             </thead>
             <tbody>
               {unidades.length === 0 && (
-                <tr><td colSpan={3} className="muted center">Sin unidades en este consorcio.</td></tr>
+                <tr>
+                  <td colSpan={3} className="muted center">
+                    {!consorcioId
+                      ? 'Elegí un consorcio.'
+                      : cargando
+                        ? 'Cargando…'
+                        : error
+                          ? 'No se pudo cargar la lista.'
+                          : 'Sin unidades en este consorcio.'}
+                  </td>
+                </tr>
               )}
               {unidades.map((u) => (
                 <tr

--- a/apps/admin-web/src/pages/UnidadesPage.tsx
+++ b/apps/admin-web/src/pages/UnidadesPage.tsx
@@ -3,10 +3,13 @@ import { useSearchParams } from 'react-router-dom';
 import { Icons } from '../components/Icons.js';
 import { Topbar } from '../components/Shell.js';
 import {
+  EVENTO_CONSORCIO_ACTIVO,
   createUnidad,
   createUnidadesBulk,
   createVinculo,
   desvincular,
+  getConsorcioActivo,
+  setConsorcioActivo,
   listConsorcios,
   listResidentes,
   listUnidades,
@@ -32,6 +35,12 @@ export function UnidadesPage(): JSX.Element {
   const [showForm, setShowForm] = useState(false);
   const [selectedUnidad, setSelectedUnidad] = useState<Unidad | null>(null);
 
+  // Esta pantalla necesita UN consorcio: no existe "las unidades de todos". Así
+  // que respeta la elección global cuando hay una, y cuando la elección es
+  // "todos" cae al primero sin sobrescribirla —si no, entrar acá cambiaría el
+  // contexto del panel entero de callado—.
+  const [cayoAlPrimero, setCayoAlPrimero] = useState(false);
+
   useEffect(() => {
     listConsorcios()
       .then((cs) => {
@@ -39,13 +48,35 @@ export function UnidadesPage(): JSX.Element {
         if (!cs.length) return;
         const fromQuery = searchParams.get('consorcio');
         if (fromQuery && cs.some((c) => c.id === fromQuery)) {
+          // Un link directo manda, y además fija el contexto del panel.
           setConsorcioId(fromQuery);
-        } else if (!consorcioId) {
+          setCayoAlPrimero(false);
+          if (getConsorcioActivo() !== fromQuery) setConsorcioActivo(fromQuery);
+          return;
+        }
+        const activo = getConsorcioActivo();
+        if (activo && cs.some((c) => c.id === activo)) {
+          setConsorcioId(activo);
+          setCayoAlPrimero(false);
+        } else {
           setConsorcioId(cs[0]!.id);
+          setCayoAlPrimero(cs.length > 1);
         }
       })
       .catch((e) => setError(e.message));
   }, [searchParams]);
+
+  useEffect(() => {
+    const sincronizar = () => {
+      const activo = getConsorcioActivo();
+      if (activo) {
+        setConsorcioId(activo);
+        setCayoAlPrimero(false);
+      }
+    };
+    window.addEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+    return () => window.removeEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
+  }, []);
 
   // Acá además hay un caso propio: sin consorcio elegido no hay nada que cargar,
   // y eso tampoco es "sin unidades".
@@ -113,7 +144,7 @@ export function UnidadesPage(): JSX.Element {
           <div className="filters-bar" style={{ padding: '0 0 12px', borderBottom: 'none' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <span className="uppercase">Consorcio</span>
-              <select value={consorcioId} onChange={(e) => setConsorcioId(e.target.value)} style={{ minWidth: 240, height: 32 }}>
+              <select value={consorcioId} onChange={(e) => setConsorcioActivo(e.target.value)} style={{ minWidth: 240, height: 32 }}>
                 {consorcios.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
               </select>
             </div>
@@ -151,6 +182,12 @@ export function UnidadesPage(): JSX.Element {
             </form>
           )}
 
+          {cayoAlPrimero && (
+            <div className="muted small">
+              Estás trabajando en “todos los consorcios”, y las unidades pertenecen a uno.
+              Mostrando el primero; elegí otro acá o en el selector de la izquierda.
+            </div>
+          )}
           {info && <div className="chip ok">{info}</div>}
           {error && <div className="error">{error}</div>}
 

--- a/apps/admin-web/src/pages/UnidadesPage.tsx
+++ b/apps/admin-web/src/pages/UnidadesPage.tsx
@@ -72,11 +72,19 @@ export function UnidadesPage(): JSX.Element {
       if (activo) {
         setConsorcioId(activo);
         setCayoAlPrimero(false);
+        return;
       }
+      // Cadena vacía es "todos", y es **falsy**: con un `if (activo)` a secas,
+      // elegir "Todos los consorcios" desde el sidebar no hacía nada acá y el
+      // cartel que explica por qué se ve un solo consorcio no aparecía. Quedaba
+      // el sidebar diciendo "todos" y esta pantalla mostrando uno, en silencio.
+      // Esta pantalla no puede listar las unidades de todos, así que se queda con
+      // el consorcio que está y lo dice.
+      setCayoAlPrimero(consorcios.length > 1);
     };
     window.addEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
     return () => window.removeEventListener(EVENTO_CONSORCIO_ACTIVO, sincronizar);
-  }, []);
+  }, [consorcios.length]);
 
   // Acá además hay un caso propio: sin consorcio elegido no hay nada que cargar,
   // y eso tampoco es "sin unidades".

--- a/apps/admin-web/src/styles.css
+++ b/apps/admin-web/src/styles.css
@@ -305,6 +305,13 @@ label > span:first-child {
 
 .form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; align-items: end; }
 .form-grid button { grid-column: -2 / -1; justify-self: end; }
+/* Ocupa la fila entera dentro de un .form-grid. Los títulos, los separadores de
+   sección, las ayudas y los campos largos (textarea) son celdas del grid como
+   cualquier otra, así que sin esto quedaban apretados al lado de los inputs y un
+   encabezado como "Su primer administrador" se leía como si fuera una etiqueta
+   más del formulario. */
+.form-grid .form-full { grid-column: 1 / -1; }
+.form-grid .form-full textarea { width: 100%; }
 
 .meta-list { display: grid; grid-template-columns: 130px 1fr; gap: 6px 12px; margin: 0; }
 .meta-list dt { color: var(--cf-ink-3); font-size: 12px; }

--- a/apps/admin-web/src/vite-env.d.ts
+++ b/apps/admin-web/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+// Hace visible `import.meta.env` para tsc. Vite lo inyecta en tiempo de build,
+// pero sin esta referencia el compilador no conoce el tipo y `import.meta.env.DEV`
+// —que es lo que deja las credenciales del seed fuera del bundle de producción—
+// no compila.

--- a/apps/admin-web/vite.config.ts
+++ b/apps/admin-web/vite.config.ts
@@ -1,13 +1,29 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+/**
+ * El destino del proxy sale del entorno, no de una constante.
+ *
+ * `API_PORT` ya existía y el resto del monorepo la respeta —la API para
+ * escuchar, el worker para llamarla, la app móvil vía `EXPO_PUBLIC_API_URL`—
+ * pero acá el puerto estaba escrito a mano. Cambiar `API_PORT` levantaba la API
+ * en el puerto nuevo y dejaba al panel pegándole al 3000, así que todo el panel
+ * fallaba con un error de red y nada indicaba por qué.
+ *
+ * Se acepta `API_URL` completa (por si la API vive en otra máquina) y, si no
+ * está, se arma con `API_PORT`. El 3000 queda como default para no cambiarle el
+ * entorno a nadie que no haya definido las variables.
+ */
+const apiTarget =
+  process.env.API_URL ?? `http://localhost:${process.env.API_PORT ?? 3000}`;
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: Number(process.env.ADMIN_WEB_PORT ?? 5173),
     proxy: {
       '/api': {
-        target: 'http://localhost:3000',
+        target: apiTarget,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "db:migrate": "node scripts/migrate.cjs",
     "seed": "node scripts/seed.cjs",
     "clean": "rm -rf dist .turbo",
-    "test:coverage": "vitest run -c vitest.integration.config.ts --coverage"
+    "test:coverage": "vitest run -c vitest.integration.config.ts --coverage",
+    "demo": "tsx scripts/demo-flujo-minimo.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1112.0",
@@ -57,6 +58,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.6.0",
     "unplugin-swc": "^1.5.11",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "tsx": "^4.19.0"
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,8 @@
     "seed": "node scripts/seed.cjs",
     "clean": "rm -rf dist .turbo",
     "test:coverage": "vitest run -c vitest.integration.config.ts --coverage",
-    "demo": "tsx scripts/demo-flujo-minimo.ts"
+    "demo": "tsx scripts/demo-flujo-minimo.ts",
+    "bot": "tsx scripts/bot-simular.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1112.0",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,8 +16,8 @@
     "seed": "node scripts/seed.cjs",
     "clean": "rm -rf dist .turbo",
     "test:coverage": "vitest run -c vitest.integration.config.ts --coverage",
-    "demo": "tsx scripts/demo-flujo-minimo.ts",
-    "bot": "tsx scripts/bot-simular.ts"
+    "demo": "tsx --env-file-if-exists=../../.env scripts/demo-flujo-minimo.ts",
+    "bot": "tsx --env-file-if-exists=../../.env scripts/bot-simular.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1112.0",

--- a/apps/api/scripts/bot-simular.ts
+++ b/apps/api/scripts/bot-simular.ts
@@ -1,0 +1,97 @@
+/**
+ * Simula que un vecino le escribe al bot, sin necesitar WhatsApp ni Telegram.
+ *
+ * Es la herramienta que faltaba para ver el producto funcionando con datos
+ * propios: los canales reales exigen credenciales del proveedor y una URL
+ * pública que Telegram pueda alcanzar, y para probar la conversación eso es
+ * andamiaje puro. Acá se llama a `BotService.handle` con el mismo objeto que
+ * armaría el webhook, así que el recorrido es idéntico salvo el transporte.
+ *
+ *   pnpm bot "+5435111111" "se rompió el portón del garage"
+ *   pnpm bot "+5435111111" "sí"          # para confirmar el reporte
+ *
+ * Las respuestas del bot se leen del outbox del mock de WhatsApp, que es lo que
+ * captura los mensajes salientes en desarrollo.
+ */
+import { BotService } from '../src/bot/bot.service.js';
+import { StorageService } from '../src/storage/storage.service.js';
+
+const MOCK_WHATSAPP = process.env.WHATSAPP_MOCK_URL ?? 'http://localhost:8081';
+
+const G = '\x1b[32m';
+const GRIS = '\x1b[90m';
+const NEGRITA = '\x1b[1m';
+const FIN = '\x1b[0m';
+
+async function enviados(): Promise<number> {
+  try {
+    const r = await fetch(`${MOCK_WHATSAPP}/__outbox`);
+    return ((await r.json()) as unknown[]).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function respuestas(desde: number): Promise<string[]> {
+  try {
+    const r = await fetch(`${MOCK_WHATSAPP}/__outbox`);
+    const todos = (await r.json()) as Array<{
+      body?: { text?: { body?: string }; type?: string };
+    }>;
+    return todos
+      .slice(desde)
+      .filter((m) => m.body?.type === 'text' && m.body?.text?.body)
+      .map((m) => m.body!.text!.body!);
+  } catch {
+    return [`${GRIS}(no pude leer el mock de WhatsApp — ¿está levantado docker compose?)${FIN}`];
+  }
+}
+
+async function main(): Promise<void> {
+  const [telefono, ...resto] = process.argv.slice(2);
+  const texto = resto.join(' ');
+
+  if (!telefono || !texto) {
+    console.error('uso: pnpm bot "<telefono E.164>" "<mensaje>"');
+    console.error('ej:  pnpm bot "+5491100000001" "se rompió el portón del garage"');
+    process.exit(1);
+  }
+
+  const bot = new BotService(new StorageService());
+  const antes = await enviados();
+
+  console.log(`\n   ${NEGRITA}Vecino (${telefono}):${FIN} ${texto}`);
+
+  const r = await bot.handle({
+    // Un id distinto por mensaje: el webhook deduplica por este valor, así que
+    // repetirlo haría que el segundo mensaje se descarte como reentrega.
+    wamid: `sim_${Date.now()}_${Math.floor(process.hrtime()[1] / 1000)}`,
+    from: telefono as `+${string}`,
+    kind: 'text',
+    text: texto,
+    receivedAt: new Date(),
+  });
+
+  for (const t of await respuestas(antes)) {
+    console.log(`\n   ${NEGRITA}${G}Bot:${FIN} ${t.replace(/\n/g, '\n        ')}`);
+  }
+
+  console.log(`\n   ${GRIS}estado: ${r.status}${r.ticketId ? ` · ticket ${r.ticketId.slice(0, 8)}` : ''}${FIN}`);
+  if (r.status === 'unregistered') {
+    console.log(
+      `   ${GRIS}ese teléfono no está cargado como vecino. Revisá que coincida exactamente${FIN}`,
+    );
+    console.log(`   ${GRIS}con el de la sección Vecinos del panel, incluido el +54.${FIN}`);
+  }
+  if (r.status === 'awaiting-report-confirm') {
+    console.log(`   ${GRIS}→ contestá con: pnpm bot "${telefono}" "sí"${FIN}`);
+  }
+  console.log();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('\nfalló:', err);
+    process.exit(1);
+  });

--- a/apps/api/scripts/demo-flujo-minimo.ts
+++ b/apps/api/scripts/demo-flujo-minimo.ts
@@ -1,0 +1,213 @@
+/**
+ * Demo del flujo mínimo del producto, de punta a punta y en el orden en que
+ * pasa en la realidad:
+ *
+ *   una administradora → su edificio → un vecino asignado a una unidad →
+ *   el vecino reclama por chat → la IA clasifica → el bot le contesta →
+ *   el reclamo aparece en la bandeja de la administradora
+ *
+ * Sirve para ver el producto funcionando sin abrir cinco pantallas, y para
+ * mostrarlo en la defensa. Llama a `BotService` directamente, así que no
+ * necesita firmar webhooks ni tener secretos del proveedor.
+ *
+ *   pnpm --filter @consorciofix/api exec tsx scripts/demo-flujo-minimo.ts
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+import { systemDb } from '../src/db/client.js';
+import {
+  clasificacionIa,
+  consorcio,
+  residente,
+  tenant as tenantTable,
+  ticket,
+  unidad,
+  vinculoResidente,
+} from '../src/db/schema/index.js';
+import { BotService } from '../src/bot/bot.service.js';
+import { StorageService } from '../src/storage/storage.service.js';
+
+const PREFIJO = `demo_${Date.now()}`;
+const TELEFONO = `+5491${String(Date.now()).slice(-9)}`;
+const MOCK_WHATSAPP = process.env.WHATSAPP_MOCK_URL ?? 'http://localhost:8081';
+
+const G = '\x1b[32m';
+const AZUL = '\x1b[36m';
+const GRIS = '\x1b[90m';
+const NEGRITA = '\x1b[1m';
+const FIN = '\x1b[0m';
+
+function paso(n: number, titulo: string): void {
+  console.log(`\n${NEGRITA}${AZUL}${n}. ${titulo}${FIN}`);
+}
+function dato(k: string, v: string): void {
+  console.log(`   ${GRIS}${k}:${FIN} ${v}`);
+}
+
+/** Lo que el bot le respondió al vecino, leído del mock de WhatsApp. */
+async function respuestasDelBot(desde: number): Promise<string[]> {
+  try {
+    const r = await fetch(`${MOCK_WHATSAPP}/__outbox`);
+    const todos = (await r.json()) as Array<{
+      body?: { to?: string; text?: { body?: string }; type?: string };
+    }>;
+    return todos
+      .slice(desde)
+      .filter((m) => m.body?.type === 'text' && m.body?.text?.body)
+      .map((m) => m.body!.text!.body!);
+  } catch {
+    return ['(no pude leer el mock de WhatsApp — ¿está levantado el docker compose?)'];
+  }
+}
+
+async function cuantosEnviados(): Promise<number> {
+  try {
+    const r = await fetch(`${MOCK_WHATSAPP}/__outbox`);
+    return ((await r.json()) as unknown[]).length;
+  } catch {
+    return 0;
+  }
+}
+
+let idTenant = '';
+
+async function main(): Promise<void> {
+  const bot = new BotService(new StorageService());
+
+  // ── 1. La administradora y su edificio ────────────────────────────────
+  paso(1, 'Una administradora contrata el sistema y carga su edificio');
+
+  const admin = (
+    await systemDb
+      .insert(tenantTable)
+      .values({ nombre: `${PREFIJO} Administración Rivadavia`, plan: 'basico' })
+      .returning()
+  )[0]!;
+  idTenant = admin.id;
+  dato('administración', admin.nombre);
+
+  const edificio = (
+    await systemDb
+      .insert(consorcio)
+      .values({ tenantId: admin.id, nombre: `${PREFIJO} Belgrano 1234`, tipo: 'EDIFICIO' })
+      .returning()
+  )[0]!;
+  dato('edificio', edificio.nombre);
+
+  const depto = (
+    await systemDb
+      .insert(unidad)
+      .values({ tenantId: admin.id, consorcioId: edificio.id, etiqueta: '3B' })
+      .returning()
+  )[0]!;
+  dato('unidad', depto.etiqueta);
+
+  // ── 2. El vecino asignado a esa unidad ────────────────────────────────
+  paso(2, 'La administradora asigna un vecino a esa unidad');
+
+  const vecino = (
+    await systemDb
+      .insert(residente)
+      .values({ tenantId: admin.id, nombre: 'Carla Domínguez', telefonoE164: TELEFONO })
+      .returning()
+  )[0]!;
+  await systemDb.insert(vinculoResidente).values({
+    tenantId: admin.id,
+    residenteId: vecino.id,
+    unidadId: depto.id,
+    rol: 'PROPIETARIO',
+    activo: true,
+  });
+  dato('vecino', `${vecino.nombre} — propietaria de la ${depto.etiqueta}`);
+  dato('teléfono', TELEFONO);
+
+  // ── 3. El vecino reclama por chat ─────────────────────────────────────
+  paso(3, 'La vecina le escribe al bot, en lenguaje suelto');
+
+  const antes = await cuantosEnviados();
+  const mensaje = 'hola, hace dos días que el portón del garage no cierra bien y queda abierto de noche';
+  console.log(`\n   ${NEGRITA}Carla:${FIN} ${mensaje}`);
+
+  const r1 = await bot.handle({
+    wamid: `${PREFIJO}_msg1`,
+    from: TELEFONO as `+${string}`,
+    kind: 'text',
+    text: mensaje,
+    receivedAt: new Date(),
+  });
+
+  for (const t of await respuestasDelBot(antes)) {
+    console.log(`\n   ${NEGRITA}${G}Bot:${FIN} ${t.replace(/\n/g, '\n        ')}`);
+  }
+  dato('\n   estado interno', r1.status);
+
+  // ── 4. Qué entendió la IA ─────────────────────────────────────────────
+  paso(4, 'Qué entendió la IA del mensaje (sugerencia, no decisión)');
+
+  const antes2 = await cuantosEnviados();
+  const r2 = await bot.handle({
+    wamid: `${PREFIJO}_msg2`,
+    from: TELEFONO as `+${string}`,
+    kind: 'text',
+    text: 'sí',
+    receivedAt: new Date(),
+  });
+  console.log(`\n   ${NEGRITA}Carla:${FIN} sí`);
+  for (const t of await respuestasDelBot(antes2)) {
+    console.log(`\n   ${NEGRITA}${G}Bot:${FIN} ${t.replace(/\n/g, '\n        ')}`);
+  }
+
+  if (!r2.ticketId) {
+    console.log('\n   (no se creó el ticket; estado:', r2.status, ')');
+    return;
+  }
+
+  const ia = (
+    await systemDb.select().from(clasificacionIa).where(eq(clasificacionIa.ticketId, r2.ticketId))
+  )[0];
+  if (ia) {
+    const sug = ia.sugerido as Record<string, unknown>;
+    console.log('');
+    dato('categoría sugerida', String(sug.categoria));
+    dato('origen sugerido', String(sug.origen));
+    dato('urgencia sugerida', String(sug.urgencia));
+    dato('confianza', `${Math.round((ia.confianza ?? 0) * 100)}%`);
+    dato('modelo', `${ia.modelo} (prompt ${ia.promptVersion})`);
+    console.log(
+      `   ${GRIS}nota:${FIN} con AI_PROVIDER=mock el modelo es un stub local. Con una key real acá van las respuestas del LLM.`,
+    );
+  }
+
+  // ── 5. El reclamo en la bandeja de la administradora ──────────────────
+  paso(5, 'El reclamo ya está en la bandeja de la administradora');
+
+  const t = (await systemDb.select().from(ticket).where(eq(ticket.id, r2.ticketId)))[0]!;
+  dato('título', t.titulo);
+  dato('estado', t.estado);
+  dato('urgencia', t.urgencia);
+  dato('edificio', edificio.nombre);
+  dato('unidad', depto.etiqueta);
+  dato('quién reportó', vecino.nombre);
+  dato('cómo llegó', 'chat — la vecina no llenó ningún formulario');
+
+  console.log(`\n${NEGRITA}${G}Ese es el producto.${FIN} Todo lo demás —costos, votos, métricas,`);
+  console.log('conducta, importar planillas— está construido alrededor de este flujo.\n');
+}
+
+main()
+  .then(async () => {
+    // La demo se limpia sola: borrar la administración arrastra todo en cascada.
+    if (idTenant) await systemDb.delete(tenantTable).where(eq(tenantTable.id, idTenant));
+    console.log(`${GRIS}(datos de la demo eliminados)${FIN}`);
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    console.error('\nla demo falló:', err);
+    if (idTenant) {
+      await systemDb.delete(tenantTable).where(eq(tenantTable.id, idTenant)).catch(() => undefined);
+    }
+    process.exit(1);
+  });
+
+void and;
+void inArray;
+void unidad;

--- a/apps/api/src/bot/bot.service.ts
+++ b/apps/api/src/bot/bot.service.ts
@@ -430,13 +430,24 @@ export class BotService {
     // la bandeja como "Agujero en el techo del pasillo" con urgencia alta. Es
     // mejor repreguntar que registrar basura — la administración abre la bandeja
     // esperando problemas reales.
-    if (classified.es_reporte === false) {
+    //
+    // Y cuando el mensaje no es un reporte pero sí una pregunta, se contesta la
+    // pregunta en vez de mandarla a repetir. "¿Cuál fue el último registro?"
+    // recibía "no encontré un problema para registrar": cierto e inútil. El
+    // ruteo cae en `responderComando`, el mismo que atiende la palabra escrita
+    // exacta, así que la lista de reportes se arma en un solo lugar.
+    if (classified.intencion !== 'REPORTE') {
+      await this.markWebhookProcessed(inbound.wamid);
+      if (classified.intencion === 'CONSULTA_ESTADO' || classified.intencion === 'AYUDA') {
+        const comando = classified.intencion === 'AYUDA' ? 'ayuda' : 'estado';
+        const r = await this.responderComando(inbound, resi, comando);
+        return { ...r, ticketId: '' };
+      }
       await this.reply(
         inbound.from,
-        'No encontré un problema para registrar en ese mensaje. Contame qué pasa y lo anoto: qué se rompió o qué está mal, y dónde.',
+        'No encontré un problema para registrar en ese mensaje. Contame qué pasa y lo anoto: qué se rompió o qué está mal, y dónde. También podés preguntarme cómo vienen tus reportes.',
         inbound,
       );
-      await this.markWebhookProcessed(inbound.wamid);
       return { status: 'sin-reporte', ticketId: '' };
     }
 
@@ -759,6 +770,8 @@ export class BotService {
         inbound.from,
         [
           'Hola. Contame qué problema hay y lo registro — podés escribirlo, mandar un audio o una foto.',
+          '',
+          'También podés preguntarme en tus palabras cómo vienen tus reportes.',
           '',
           'Comandos:',
           '• *estado* — cómo vienen tus reportes',

--- a/apps/api/src/bot/bot.service.ts
+++ b/apps/api/src/bot/bot.service.ts
@@ -84,7 +84,53 @@ export class BotService {
    * Palabras que el bot interpreta como comando y no como reporte. Se aceptan
    * con y sin barra: por WhatsApp nadie escribe "/estado".
    */
+  /**
+   * Cómo dice "sí" y "no" un vecino por chat.
+   *
+   * Están acá y no repetidos en cada handler porque las dos confirmaciones del
+   * bot —registrar el reporte y sumar el voto a un duplicado— aceptaban palabras
+   * distintas: "dale" servía para registrar y fallaba para votar, y el vecino
+   * recibía "No te entendí" sin motivo. Si mañana se agrega otra confirmación,
+   * hereda el mismo vocabulario.
+   */
+  private static readonly AFIRMA = /^(s|si|sí|sip|dale|ok|oka|okey|listo|confirmo|correcto|obvio|1)$/i;
+  private static readonly NIEGA = /^(n|no|nop|nope|cancelar|mal|negativo|2)$/i;
+
+  /**
+   * Cortesías que no son un reporte ni un comando. Se atajan antes de llamar al
+   * modelo: además de evitar el ticket inventado, ahorra una llamada paga por
+   * cada "gracias".
+   */
+  private static readonly CORTESIAS = new Set([
+    'gracias',
+    'muchas gracias',
+    'mil gracias',
+    'ok',
+    'oka',
+    'okey',
+    'dale',
+    'perfecto',
+    'buenisimo',
+    'buenísimo',
+    'genial',
+    'listo',
+    'barbaro',
+    'bárbaro',
+    'de nada',
+    'chau',
+    'saludos',
+    'buenas',
+    'buen dia',
+    'buen día',
+    'buenas tardes',
+    'buenas noches',
+  ]);
+
   private static readonly COMANDOS_SET = new Set([
+    // Singular y plural: el menú de ayuda anuncia "estado", y escribir justo la
+    // palabra que el bot te dijo tiene que funcionar. Antes solo estaba el
+    // plural, así que "estado" caía en la lista de cortesías y el vecino recibía
+    // "cuando necesites algo, contame" en lugar de sus reportes.
     'estado',
     'estados',
     'mis reportes',
@@ -157,8 +203,22 @@ export class BotService {
       return this.responderComando(inbound, resi, comando);
     }
 
-    // Sesión activa: ruteo según step.
+    // Una cortesía suelta no es un reporte. Ojo: solo cuando NO hay una sesión
+    // esperando respuesta, porque ahí "dale" u "ok" significan "sí, registralo".
     const session = await getActiveSession(inbound.from);
+    const cortesia = comando.replace(/[!¡.]+$/, '');
+    if (inbound.kind === 'text' && !session && BotService.CORTESIAS.has(cortesia)) {
+      // "De nada" a un "chau" queda raro, así que el agradecimiento se responde
+      // distinto del saludo de salida.
+      const texto = /gracias/.test(cortesia)
+        ? 'De nada. Cuando necesites algo, contame y lo registro.'
+        : 'Cuando necesites algo, contame y lo registro.';
+      await this.reply(inbound.from, texto, inbound);
+      await this.markWebhookProcessed(inbound.wamid);
+      return { status: 'cortesia' };
+    }
+
+    // Sesión activa: ruteo según step.
     if (session?.state.step === 'pick_consorcio') {
       return this.handleConsorcioChoice(inbound, resi, session.state);
     }
@@ -297,7 +357,7 @@ export class BotService {
     state: SessionState,
   ): Promise<{ status: string; ticketId?: string }> {
     const raw = (inbound.text ?? '').trim().toLowerCase();
-    const yes = /^(s|si|sí|yes|y|1)$/i.test(raw);
+    const yes = BotService.AFIRMA.test(raw);
     const no = /^(n|no|2)$/i.test(raw);
     if (!yes && !no) {
       await this.reply(inbound.from, 'Respondé Sí para sumar tu voto al reporte existente, o No para crear uno nuevo.', inbound);
@@ -363,6 +423,21 @@ export class BotService {
       this.log.error({ err: (err as Error).message }, 'classifier failed');
       await this.reply(inbound.from, 'No pude procesar tu reporte en este momento. Probá de nuevo en unos minutos.', inbound);
       return { status: 'classifier-error', ticketId: '' };
+    }
+
+    // El clasificador puede abstenerse (RF-B06). Sin esto, cualquier mensaje sin
+    // contenido salía convertido en un reclamo inventado: un "Gracias" llegaba a
+    // la bandeja como "Agujero en el techo del pasillo" con urgencia alta. Es
+    // mejor repreguntar que registrar basura — la administración abre la bandeja
+    // esperando problemas reales.
+    if (classified.es_reporte === false) {
+      await this.reply(
+        inbound.from,
+        'No encontré un problema para registrar en ese mensaje. Contame qué pasa y lo anoto: qué se rompió o qué está mal, y dónde.',
+        inbound,
+      );
+      await this.markWebhookProcessed(inbound.wamid);
+      return { status: 'sin-reporte', ticketId: '' };
     }
 
     let embedding: number[];
@@ -749,8 +824,8 @@ export class BotService {
       return { status: 'confirm-session-corrupt' };
     }
 
-    const si = /^(s[ií]|si|dale|ok|confirmo|correcto|1)$/.test(raw);
-    const no = /^(no|cancelar|mal|2)$/.test(raw);
+    const si = BotService.AFIRMA.test(raw);
+    const no = BotService.NIEGA.test(raw);
 
     if (!si && !no) {
       // Cualquier otra cosa se interpreta como una corrección: el residente

--- a/apps/api/src/bot/bot.service.ts
+++ b/apps/api/src/bot/bot.service.ts
@@ -97,7 +97,7 @@ export class BotService {
 
   async handle(inbound: InboundMessage): Promise<{ status: string; ticketId?: string }> {
     if (inbound.kind === 'other') {
-      await this.reply(inbound.from, 'Formato no soportado. Mandá texto o foto.');
+      await this.reply(inbound.from, 'Formato no soportado. Mandá texto o foto.', inbound);
       return { status: 'unsupported-kind' };
     }
 
@@ -129,7 +129,7 @@ export class BotService {
       await this.reply(
         inbound.from,
         'Tu número figura en más de una administración, así que no puedo saber a cuál corresponde este reporte. Contactá a tu administración para que lo resuelvan.',
-      );
+        inbound);
       await this.markWebhookProcessed(inbound.wamid);
       return { status: 'ambiguous-tenant' };
     }
@@ -171,7 +171,7 @@ export class BotService {
 
     const consorcios = await this.consorciosDelResidente(resi.id, resi.tenantId);
     if (consorcios.length === 0) {
-      await this.reply(inbound.from, 'No tenés consorcios activos. Contactá a tu administración.');
+      await this.reply(inbound.from, 'No tenés consorcios activos. Contactá a tu administración.', inbound);
       return { status: 'no-active-consorcios' };
     }
 
@@ -181,7 +181,7 @@ export class BotService {
     let mediaPendiente: MediaPendiente | null = null;
     if (inbound.kind === 'audio') {
       if (!inbound.mediaId) {
-        await this.reply(inbound.from, 'No pude recuperar tu audio. Probá escribirlo.');
+        await this.reply(inbound.from, 'No pude recuperar tu audio. Probá escribirlo.', inbound);
         return { status: 'audio-no-mediaid' };
       }
       try {
@@ -198,17 +198,17 @@ export class BotService {
         const tr = await this.transcriber.transcribe(dl.bytes, { language: 'es' });
         text = (tr.text ?? '').trim();
         if (text.length === 0) {
-          await this.reply(inbound.from, 'No te entendí el audio. ¿Podés escribirlo?');
+          await this.reply(inbound.from, 'No te entendí el audio. ¿Podés escribirlo?', inbound);
           return { status: 'audio-empty-transcript' };
         }
       } catch (err) {
         this.log.warn({ err: (err as Error).message }, 'transcription failed');
-        await this.reply(inbound.from, 'No pude procesar tu audio. ¿Podés escribirlo?');
+        await this.reply(inbound.from, 'No pude procesar tu audio. ¿Podés escribirlo?', inbound);
         return { status: 'audio-error' };
       }
     } else if (inbound.kind === 'image') {
       if (!inbound.mediaId) {
-        await this.reply(inbound.from, 'No pude recuperar tu foto. Probá describir con texto qué pasa.');
+        await this.reply(inbound.from, 'No pude recuperar tu foto. Probá describir con texto qué pasa.', inbound);
         return { status: 'image-no-mediaid' };
       }
       try {
@@ -224,7 +224,7 @@ export class BotService {
           promptVersion: VISION_PROMPT_VERSION,
         });
         if (!v.apropiado) {
-          await this.reply(inbound.from, 'La foto que mandaste no parece relacionada con un problema del consorcio. Probá mandar otra o describí con texto.');
+          await this.reply(inbound.from, 'La foto que mandaste no parece relacionada con un problema del consorcio. Probá mandar otra o describí con texto.', inbound);
           return { status: 'image-not-appropriate' };
         }
         // Merge: visión describe lo visible + lo que el usuario escribió.
@@ -232,12 +232,12 @@ export class BotService {
         text = userText.length > 0 ? `${userText}. ${v.descripcion}` : v.descripcion;
       } catch (err) {
         this.log.warn({ err: (err as Error).message }, 'vision failed');
-        await this.reply(inbound.from, 'No pude analizar la foto. Probá describir con texto qué pasa.');
+        await this.reply(inbound.from, 'No pude analizar la foto. Probá describir con texto qué pasa.', inbound);
         return { status: 'image-error' };
       }
     }
     if (text.length === 0) {
-      await this.reply(inbound.from, 'Mensaje vacío. Contame qué pasa.');
+      await this.reply(inbound.from, 'Mensaje vacío. Contame qué pasa.', inbound);
       return { status: 'empty' };
     }
 
@@ -252,7 +252,7 @@ export class BotService {
       await this.reply(
         inbound.from,
         `Tenés ${consorcios.length} consorcios. ¿A cuál refiere el reporte?\n${list}\n\nRespondé con el número.`,
-      );
+        inbound);
       return { status: 'awaiting-consorcio-choice' };
     }
 
@@ -278,14 +278,14 @@ export class BotService {
     const options = state.options ?? [];
     if (!Number.isInteger(n) || n < 1 || n > options.length) {
       const list = options.map((o, i) => `${i + 1}. ${o.nombre}`).join('\n');
-      await this.reply(inbound.from, `No entendí. Respondé con un número del 1 al ${options.length}.\n${list}`);
+      await this.reply(inbound.from, `No entendí. Respondé con un número del 1 al ${options.length}.\n${list}`, inbound);
       return { status: 'consorcio-choice-invalid' };
     }
     const chosen = options[n - 1]!;
     const pendingText = state.pendingText ?? '';
     await clearSession(inbound.from);
     if (!pendingText) {
-      await this.reply(inbound.from, `Listo, consorcio ${chosen.nombre}. Contame qué pasa.`);
+      await this.reply(inbound.from, `Listo, consorcio ${chosen.nombre}. Contame qué pasa.`, inbound);
       return { status: 'consorcio-chosen-no-pending' };
     }
     return this.classifyDedupCreate(inbound, resi, chosen.consorcioId, chosen.unidadId, pendingText);
@@ -300,14 +300,14 @@ export class BotService {
     const yes = /^(s|si|sí|yes|y|1)$/i.test(raw);
     const no = /^(n|no|2)$/i.test(raw);
     if (!yes && !no) {
-      await this.reply(inbound.from, 'Respondé Sí para sumar tu voto al reporte existente, o No para crear uno nuevo.');
+      await this.reply(inbound.from, 'Respondé Sí para sumar tu voto al reporte existente, o No para crear uno nuevo.', inbound);
       return { status: 'dedup-confirm-invalid' };
     }
     const candidate = state.dedupCandidate;
     const inputs = state.pendingTicketInputs;
     if (!candidate || !inputs) {
       await clearSession(inbound.from);
-      await this.reply(inbound.from, 'Tu sesión expiró. Volvé a mandar el reporte.');
+      await this.reply(inbound.from, 'Tu sesión expiró. Volvé a mandar el reporte.', inbound);
       return { status: 'dedup-session-corrupt' };
     }
 
@@ -319,6 +319,7 @@ export class BotService {
       await this.reply(
         inbound.from,
         `Sumé tu voto al reporte "${candidate.titulo}" (#${candidate.ticketId.slice(0, 8)}). Te vamos a notificar cuando avance.`,
+        inbound,
       );
       return { status: 'voted-existing', ticketId: candidate.ticketId };
     }
@@ -341,6 +342,7 @@ export class BotService {
     await this.reply(
       inbound.from,
       `Ok, registré un reporte nuevo (#${t.id.slice(0, 8)}). Categoría: ${inputs.classifiedCategoria}, urgencia: ${inputs.classifiedUrgencia}. El administrador lo va a validar.`,
+      inbound,
     );
     return { status: 'created-new', ticketId: t.id };
   }
@@ -359,7 +361,7 @@ export class BotService {
       classified = await this.classifier.classify(text, { promptVersion: CLASSIFIER_PROMPT_VERSION });
     } catch (err) {
       this.log.error({ err: (err as Error).message }, 'classifier failed');
-      await this.reply(inbound.from, 'No pude procesar tu reporte en este momento. Probá de nuevo en unos minutos.');
+      await this.reply(inbound.from, 'No pude procesar tu reporte en este momento. Probá de nuevo en unos minutos.', inbound);
       return { status: 'classifier-error', ticketId: '' };
     }
 
@@ -397,7 +399,9 @@ export class BotService {
               classifiedConfianza: classified.confianza,
               classifiedModelo: classified.modelo,
               classifiedPromptVersion: classified.prompt_version,
-              ...(classified.ubicacion !== undefined && { classifiedUbicacion: classified.ubicacion }),
+              // `!= null` cubre null y undefined: el modelo ahora manda null explícito
+          // cuando el reporte no dice dónde, y la sesión guarda solo strings.
+          ...(classified.ubicacion != null && { classifiedUbicacion: classified.ubicacion }),
               embedding,
             },
           });
@@ -405,6 +409,7 @@ export class BotService {
           await this.reply(
             inbound.from,
             `Ya hay un reporte parecido: "${candidate.titulo}" (#${candidate.ticketId.slice(0, 8)}). ¿Sumás tu voto? Respondé Sí o No.`,
+            inbound,
           );
           return { status: 'dedup-offered', ticketId: candidate.ticketId };
         }
@@ -438,7 +443,9 @@ export class BotService {
           classifiedConfianza: classified.confianza,
           classifiedModelo: classified.modelo,
           classifiedPromptVersion: classified.prompt_version,
-          ...(classified.ubicacion !== undefined && { classifiedUbicacion: classified.ubicacion }),
+          // `!= null` cubre null y undefined: el modelo ahora manda null explícito
+          // cuando el reporte no dice dónde, y la sesión guarda solo strings.
+          ...(classified.ubicacion != null && { classifiedUbicacion: classified.ubicacion }),
           ...(classified.uso ? { classifiedUso: classified.uso } : {}),
           ...(subida ? { mediaSubida: subida } : {}),
           embedding,
@@ -484,6 +491,7 @@ export class BotService {
       classified.tipo === 'CONDUCTA'
         ? `Listo, registré tu reporte de convivencia (#${t.id.slice(0, 8)}). Es anónimo: el vecino nunca va a saber quién lo reportó. El administrador lo va a revisar.`
         : `Listo, registré tu reporte (#${t.id.slice(0, 8)}). Categoría: ${classified.categoria}, urgencia: ${classified.urgencia}. El administrador lo va a validar.`,
+      inbound,
     );
     return { status: 'created', ticketId: t.id };
   }
@@ -884,7 +892,20 @@ export class BotService {
    * Responde por el MISMO canal del que vino el mensaje. Sin esto, un reporte
    * hecho por Telegram recibiría la respuesta por WhatsApp — o no la recibiría.
    */
-  private async reply(to: string, text: string, inbound?: InboundMessage) {
+  /**
+   * Responde al vecino por el canal del que vino el mensaje.
+   *
+   * `inbound` es OBLIGATORIO a propósito. Era opcional, y cada llamada que se lo
+   * olvidaba caía al proveedor de WhatsApp aunque el mensaje hubiera entrado por
+   * Telegram: el texto salía dirigido al `chat_id` como si fuera un teléfono, así
+   * que el vecino no recibía nada y el mensaje terminaba en el outbox del mock.
+   * Verificado con un Telegram real: "No tenés consorcios activos" salió a
+   * WhatsApp con destino 5050393967, que es un chat_id.
+   *
+   * Con el parámetro obligatorio el compilador señala cualquier llamada que se
+   * olvide del canal, así que el error no puede volver a colarse.
+   */
+  private async reply(to: string, text: string, inbound: InboundMessage) {
     try {
       if (inbound?.channel === 'telegram') {
         const destino = inbound.externalId ?? to;

--- a/apps/api/src/bot/bot.service.ts
+++ b/apps/api/src/bot/bot.service.ts
@@ -141,7 +141,26 @@ export class BotService {
     'menú',
   ]);
 
+  /**
+   * Única puerta de entrada. Marca el webhook como procesado en un solo lugar.
+   *
+   * Antes cada camino se acordaba —o se olvidaba— de marcarlo por su cuenta, y
+   * de ~15 salidas solo cuatro lo hacían: los comandos, los mensajes vacíos y
+   * los errores de audio quedaban en RECIBIDO para siempre (23 de 52 eventos en
+   * desarrollo). Como `wamid` es la clave de idempotencia de la regla 3, una
+   * reentrega del proveedor los habría vuelto a contestar.
+   *
+   * Marcarlo acá y no en cada rama tiene además la semántica correcta: si el
+   * manejo termina sin excepción, ya le respondimos al vecino y no hay que
+   * repetirlo; si lanza, el evento queda sin marcar y una reentrega lo reintenta.
+   */
   async handle(inbound: InboundMessage): Promise<{ status: string; ticketId?: string }> {
+    const r = await this.despachar(inbound);
+    await this.markWebhookProcessed(inbound.wamid);
+    return r;
+  }
+
+  private async despachar(inbound: InboundMessage): Promise<{ status: string; ticketId?: string }> {
     if (inbound.kind === 'other') {
       await this.reply(inbound.from, 'Formato no soportado. Mandá texto o foto.', inbound);
       return { status: 'unsupported-kind' };
@@ -176,7 +195,6 @@ export class BotService {
         inbound.from,
         'Tu número figura en más de una administración, así que no puedo saber a cuál corresponde este reporte. Contactá a tu administración para que lo resuelvan.',
         inbound);
-      await this.markWebhookProcessed(inbound.wamid);
       return { status: 'ambiguous-tenant' };
     }
     // RF-G02: registrar el inbound abre la ventana de 24 h para poder
@@ -214,7 +232,6 @@ export class BotService {
         ? 'De nada. Cuando necesites algo, contame y lo registro.'
         : 'Cuando necesites algo, contame y lo registro.';
       await this.reply(inbound.from, texto, inbound);
-      await this.markWebhookProcessed(inbound.wamid);
       return { status: 'cortesia' };
     }
 
@@ -372,7 +389,6 @@ export class BotService {
     }
 
     await clearSession(inbound.from);
-    await this.markWebhookProcessed(inbound.wamid);
 
     if (yes) {
       await this.castVote(resi.tenantId, candidate.ticketId, resi.id);
@@ -437,7 +453,6 @@ export class BotService {
     // ruteo cae en `responderComando`, el mismo que atiende la palabra escrita
     // exacta, así que la lista de reportes se arma en un solo lugar.
     if (classified.intencion !== 'REPORTE') {
-      await this.markWebhookProcessed(inbound.wamid);
       if (classified.intencion === 'CONSULTA_ESTADO' || classified.intencion === 'AYUDA') {
         const comando = classified.intencion === 'AYUDA' ? 'ayuda' : 'estado';
         const r = await this.responderComando(inbound, resi, comando);
@@ -491,7 +506,6 @@ export class BotService {
               embedding,
             },
           });
-          await this.markWebhookProcessed(inbound.wamid);
           await this.reply(
             inbound.from,
             `Ya hay un reporte parecido: "${candidate.titulo}" (#${candidate.ticketId.slice(0, 8)}). ¿Sumás tu voto? Respondé Sí o No.`,
@@ -537,7 +551,6 @@ export class BotService {
           embedding,
         },
       });
-      await this.markWebhookProcessed(inbound.wamid);
       await this.reply(inbound.from, resumenDeReporte(classified), inbound);
       return { status: 'awaiting-report-confirm', ticketId: '' };
     }
@@ -571,7 +584,6 @@ export class BotService {
       t.id,
       mediaYaSubida ?? (await this.subirMedia(resi.tenantId, mediaPendiente)),
     );
-    await this.markWebhookProcessed(inbound.wamid);
     await this.reply(
       inbound.from,
       classified.tipo === 'CONDUCTA'
@@ -832,7 +844,6 @@ export class BotService {
     const inputs = state.pendingTicketInputs;
     if (!inputs) {
       await clearSession(inbound.from);
-      await this.markWebhookProcessed(inbound.wamid);
       await this.reply(inbound.from, 'Se me perdió el reporte. ¿Me lo contás de nuevo?', inbound);
       return { status: 'confirm-session-corrupt' };
     }
@@ -847,7 +858,6 @@ export class BotService {
       // descartado en cada vuelta — y una FOTO acá dejaba el webhook_event en
       // PENDIENTE para siempre.
       await clearSession(inbound.from);
-      await this.markWebhookProcessed(inbound.wamid);
       if (inbound.kind === 'text' && raw.length > 0) {
         await this.reply(inbound.from, 'Ok, tomo esto como la versión corregida.', inbound);
         // Se reprocesa como reporte nuevo, ya sin sesión, ARRASTRANDO la media
@@ -866,7 +876,6 @@ export class BotService {
 
     if (no) {
       await clearSession(inbound.from);
-      await this.markWebhookProcessed(inbound.wamid);
       await this.reply(
         inbound.from,
         'Listo, lo descarté. Contame de nuevo qué pasa y lo registro como me digas.',
@@ -895,7 +904,6 @@ export class BotService {
 
     await this.asociarMediaSubida(resi.tenantId, t.id, inputs.mediaSubida);
     await clearSession(inbound.from);
-    await this.markWebhookProcessed(inbound.wamid);
 
     await this.reply(
       inbound.from,

--- a/apps/api/src/conducta/conducta.controller.ts
+++ b/apps/api/src/conducta/conducta.controller.ts
@@ -56,7 +56,13 @@ export class ConductaController {
     const t = tid(req);
     const created = await withTenant(t, async (tx) => {
       const tk = (await tx
-        .select({ id: ticket.id, unidadId: ticket.unidadId, tipo: ticket.tipo })
+        .select({
+          id: ticket.id,
+          unidadId: ticket.unidadId,
+          unidadReportadaId: ticket.unidadReportadaId,
+          tipo: ticket.tipo,
+          estado: ticket.estado,
+        })
         .from(ticket)
         .where(and(eq(ticket.tenantId, t), eq(ticket.id, ticketId)))
         .limit(1))[0];
@@ -64,14 +70,23 @@ export class ConductaController {
       if (tk.tipo !== 'CONDUCTA') {
         throw new ForbiddenException('registro_conducta solo aplica a tickets tipo CONDUCTA');
       }
-      if (!tk.unidadId) {
-        throw new ForbiddenException('ticket de conducta sin unidad reportada');
+      // La sanción va contra la unidad ACUSADA, que desde la migración 0004 vive
+      // en su propia columna. Acá se leía `unidad_id`, que en un ticket creado
+      // por el bot es la unidad del DENUNCIANTE —el bot imputa la unidad de quien
+      // escribe—, así que un aviso o una sanción quedaban registrados contra el
+      // vecino que hizo la denuncia y le ensuciaban su propio historial de
+      // convivencia (RF-F03). La 0004 hizo el backfill de los tickets viejos, así
+      // que exigir la columna nueva no deja ninguno afuera.
+      if (!tk.unidadReportadaId) {
+        throw new ForbiddenException(
+          'el ticket todavía no tiene unidad señalada: validalo indicando a qué unidad corresponde',
+        );
       }
       return (await tx
         .insert(registroConducta)
         .values({
           tenantId: t,
-          unidadId: tk.unidadId,
+          unidadId: tk.unidadReportadaId,
           ticketId,
           resultado: dto.resultado,
           detalle: dto.detalle ?? null,

--- a/apps/api/src/core-admin/consorcios.controller.ts
+++ b/apps/api/src/core-admin/consorcios.controller.ts
@@ -50,20 +50,32 @@ export class ConsorciosController {
     return row[0];
   }
 
+  /**
+   * El `if (!row)` no es decorativo: el WHERE ya acota por `tenant_id`, así que
+   * editar un consorcio de otra administración no toca ninguna fila —pero sin
+   * este chequeo el UPDATE de 0 filas devolvía 200 con body vacío y el panel
+   * mostraba "guardado" sin haber guardado nada. Mismo criterio que
+   * `vinculos.update`. Verificado en runtime: AdminB hacía PATCH sobre un
+   * consorcio de AdminA y recibía 200.
+   */
   @Patch(':id')
   async update(@Req() req: AuthedRequest, @Param('id') id: string, @Body() body: unknown) {
     const dto = UpdateBody.parse(body);
     const tid = tenantIdFromReq(req);
-    return withTenant(tid, async (tx) =>
-      (await tx
-        .update(consorcio)
-        .set({
-          ...(dto.nombre !== undefined && { nombre: dto.nombre }),
-          ...(dto.direccion !== undefined && { direccion: dto.direccion }),
-          ...(dto.archivado !== undefined && { archivado: dto.archivado }),
-        })
-        .where(and(eq(consorcio.tenantId, tid), eq(consorcio.id, id)))
-        .returning())[0],
-    );
+    return withTenant(tid, async (tx) => {
+      const row = (
+        await tx
+          .update(consorcio)
+          .set({
+            ...(dto.nombre !== undefined && { nombre: dto.nombre }),
+            ...(dto.direccion !== undefined && { direccion: dto.direccion }),
+            ...(dto.archivado !== undefined && { archivado: dto.archivado }),
+          })
+          .where(and(eq(consorcio.tenantId, tid), eq(consorcio.id, id)))
+          .returning()
+      )[0];
+      if (!row) throw new NotFoundException();
+      return row;
+    });
   }
 }

--- a/apps/api/src/import/import.service.ts
+++ b/apps/api/src/import/import.service.ts
@@ -214,7 +214,13 @@ export class ImportService {
             unidadId = nueva.id;
             porEtiqueta.set(clave, unidadId);
           } else {
+            // También se marca en la prueba, y no solo al escribir: sin esto
+            // cada fila que apunta a la misma unidad nueva la volvía a contar,
+            // así que una planilla con dos ocupantes por unidad informaba el
+            // doble de unidades a crear. El admin usa justamente esta vista
+            // previa para decidir si aplica el archivo.
             unidadId = 'dry-run';
+            porEtiqueta.set(clave, unidadId);
           }
           resultado.unidadesCreadas.push(v.unidad.trim());
         }

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -13,8 +13,10 @@ interface NotifyArgs {
   ticketId: string;
   shortCode: string;
   to: TicketState;
-  nota: string | null;
   reportanteId: string | null;
+  // `nota` se quitó a propósito: era la nota INTERNA del admin y terminaba en el
+  // mensaje que recibe el vecino. Sacarla del contrato hace que el compilador
+  // señale a cualquiera que intente volver a pasarla.
 }
 
 /**
@@ -260,7 +262,7 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
       .from(residente)
       .where(and(eq(residente.tenantId, args.tenantId), inArray(residente.id, ids)));
 
-    const text = tpl.body({ short: args.shortCode, nota: args.nota ?? '' });
+    const text = tpl.body({ short: args.shortCode });
 
     for (const r of rows) {
       // 1. WhatsApp channel.
@@ -292,7 +294,7 @@ export class NotificationsService implements OnModuleInit, OnModuleDestroy {
             estado: 'PENDIENTE',
           })
           .returning({ id: notificacion.id });
-        void this.sendPush(pushNotif[0]!.id, r.pushToken, args.shortCode, args.to, args.nota);
+        void this.sendPush(pushNotif[0]!.id, r.pushToken, args.shortCode, args.to, null);
       }
     }
   }

--- a/apps/api/src/notifications/templates.ts
+++ b/apps/api/src/notifications/templates.ts
@@ -4,6 +4,16 @@ import type { TicketState } from '@consorciofix/domain';
  * Plantillas de notificación en español (es-AR).
  * Cuando se integre Meta Business, registrar como HSM con estos mismos nombres
  * y mapear `variables` a parámetros de body.
+ *
+ * **Ninguna plantilla interpola la nota del admin.** Las tres lo hacían, y esa
+ * nota la pide el panel bajo el rótulo "NOTA INTERNA — contexto para el equipo":
+ * escribir ahí "ojo que este vecino reclama por todo" se lo mandaba por WhatsApp
+ * al vecino, y no solo al que reportó —la notificación va también a todos los que
+ * votaron el ticket—. Un texto libre pedido como privado no puede terminar en un
+ * mensaje saliente.
+ *
+ * Si hace falta decirle algo al vecino al cambiar de estado, va en un campo
+ * propio con su rótulo ("mensaje para el vecino"), no reusando el interno.
  */
 export interface Template {
   name: string;
@@ -14,23 +24,17 @@ export const NOTIFICATION_TEMPLATES: Record<string, Template> = {
   ticket_validated: {
     name: 'ticket_validated',
     body: (v) =>
-      `Tu reporte #${v.short} fue validado por el administrador. Estado actual: VALIDADO.${
-        v.nota ? `\nNota: ${v.nota}` : ''
-      }`,
+      `Tu reporte #${v.short} fue validado por el administrador. Estado actual: VALIDADO.`,
   },
   ticket_solucionado: {
     name: 'ticket_solucionado',
     body: (v) =>
-      `Buenas noticias: tu reporte #${v.short} fue marcado como SOLUCIONADO.${
-        v.nota ? `\nNota: ${v.nota}` : ''
-      }`,
+      `Buenas noticias: tu reporte #${v.short} fue marcado como SOLUCIONADO.`,
   },
   ticket_descartado: {
     name: 'ticket_descartado',
     body: (v) =>
-      `Tu reporte #${v.short} fue descartado por el administrador.${
-        v.nota ? `\nMotivo: ${v.nota}` : ''
-      }`,
+      `Tu reporte #${v.short} fue descartado por el administrador.`,
   },
 };
 

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -300,7 +300,22 @@ export class TicketsService {
         transicion: e.transicion,
         estadoAnterior: e.estadoAnterior,
         estadoNuevo: e.estadoNuevo,
-        ...(esAdmin || !esConducta ? { nota: e.nota } : {}),
+        // La nota es SOLO del admin, en todo tipo de ticket.
+        //
+        // Antes se ocultaba nada más en CONDUCTA, así que en un ticket de
+        // infraestructura un residente que pidiera el historial leía la nota
+        // interna. El panel la pide bajo el rótulo "NOTA INTERNA — contexto para
+        // el equipo": si el vecino puede leerla, el rótulo miente, y quien la
+        // escribe cree que está en privado. Es un campo de texto libre, así que
+        // no se puede confiar en que quien lo llena se autocensure.
+        //
+        // Si algún día hace falta un comentario que el vecino SÍ vea, va en otro
+        // campo con su propio rótulo. Un mismo texto libre no puede servir para
+        // las dos cosas.
+        ...(esAdmin ? { nota: e.nota } : {}),
+        // `autorTipo: 'RESIDENTE'` en el evento de creación le confirma al
+        // acusado que lo denunció un vecino y no la administración, así que en
+        // conducta sigue oculto.
         ...(esAdmin || !esConducta ? { autorTipo: e.autorTipo } : {}),
         ...(esAdmin ? { autorId: e.autorId } : {}),
         at: e.at,

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -472,7 +472,8 @@ export class TicketsService {
         ticketId: updated.id,
         shortCode: updated.id.slice(0, 8),
         to,
-        nota: opts.nota ?? null,
+        // La nota NO viaja: es interna del admin. Iba en el cuerpo del mensaje
+        // que recibe el vecino —y todos los que votaron el ticket—.
         reportanteId: updated.reportanteId,
       });
     });

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -27,6 +27,39 @@ export interface CreateTicketInput {
   creadoPorAdminId?: string;
 }
 
+/**
+ * Columnas del ticket que se exponen por HTTP.
+ *
+ * Existe para dejar afuera `embedding`: es un vector de 384 floats que sirve
+ * para el dedup del lado del servidor y que ningún cliente usa, pero
+ * `select()` lo traía igual y se serializaba como ~877 bytes por ticket. En un
+ * consorcio con tickets creados por el bot era casi la mitad del peso de la
+ * bandeja (medido: 47% de la respuesta).
+ */
+const COLUMNAS_PUBLICAS = {
+  id: ticket.id,
+  tenantId: ticket.tenantId,
+  consorcioId: ticket.consorcioId,
+  unidadId: ticket.unidadId,
+  unidadReportadaId: ticket.unidadReportadaId,
+  reportanteId: ticket.reportanteId,
+  tipo: ticket.tipo,
+  origen: ticket.origen,
+  urgencia: ticket.urgencia,
+  estado: ticket.estado,
+  titulo: ticket.titulo,
+  descripcionNormalizada: ticket.descripcionNormalizada,
+  clientGeneratedId: ticket.clientGeneratedId,
+  shortCode: ticket.shortCode,
+  votosCount: ticket.votosCount,
+  categoriaId: ticket.categoriaId,
+  duplicadoDeId: ticket.duplicadoDeId,
+  createdAt: ticket.createdAt,
+  validatedAt: ticket.validatedAt,
+  solucionadoAt: ticket.solucionadoAt,
+  updatedAt: ticket.updatedAt,
+} as const;
+
 @Injectable()
 export class TicketsService {
   constructor(
@@ -135,7 +168,12 @@ export class TicketsService {
       const conds = [eq(ticket.tenantId, tenantId)];
       if (opts.consorcioId) conds.push(eq(ticket.consorcioId, opts.consorcioId));
       if (opts.estado) conds.push(eq(ticket.estado, opts.estado));
-      return tx.select().from(ticket).where(and(...conds)).orderBy(desc(ticket.createdAt)).limit(200);
+      return tx
+        .select(COLUMNAS_PUBLICAS)
+        .from(ticket)
+        .where(and(...conds))
+        .orderBy(desc(ticket.createdAt))
+        .limit(200);
     });
   }
 
@@ -154,11 +192,44 @@ export class TicketsService {
    */
   async byId(tenantId: string, id: string, viewer: TicketViewer) {
     return withTenant(tenantId, async (tx) => {
-      const rows = await tx.select().from(ticket).where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, id))).limit(1);
+      const rows = await tx
+        .select(COLUMNAS_PUBLICAS)
+        .from(ticket)
+        .where(and(eq(ticket.tenantId, tenantId), eq(ticket.id, id)))
+        .limit(1);
       const t = rows[0];
       if (!t) throw new NotFoundException('ticket not found');
 
-      if (viewer.kind !== 'RESIDENTE') return t;
+      if (viewer.kind !== 'RESIDENTE') {
+        // La sugerencia de la IA va SOLO al admin, y solo acá: es lo que la
+        // regla 4 le pide decidir, y hasta ahora el panel no la recibía nunca
+        // —mostraba una confianza fija del 85% y derivaba la "categoría
+        // sugerida" de los campos ya confirmados, o sea de su propia decisión.
+        // Al residente no se le expone: en CONDUCTA el `sugerido` contiene el
+        // texto crudo del denunciante y la unidad que el modelo dedujo.
+        const ia = (
+          await tx
+            .select({
+              sugerido: clasificacionIa.sugerido,
+              corregidoPorAdmin: clasificacionIa.corregidoPorAdmin,
+              confianza: clasificacionIa.confianza,
+              modelo: clasificacionIa.modelo,
+              promptVersion: clasificacionIa.promptVersion,
+              tokensIn: clasificacionIa.tokensIn,
+              tokensOut: clasificacionIa.tokensOut,
+              costoUsd: clasificacionIa.costoUsd,
+              latenciaMs: clasificacionIa.latenciaMs,
+              cacheHit: clasificacionIa.cacheHit,
+            })
+            .from(clasificacionIa)
+            .where(and(eq(clasificacionIa.tenantId, tenantId), eq(clasificacionIa.ticketId, id)))
+            .limit(1)
+        )[0];
+        // `null` explícito y no ausencia: un ticket cargado a mano por el admin
+        // no pasó por el clasificador, y el panel tiene que poder distinguirlo
+        // de "todavía no llegó".
+        return { ...t, clasificacion: ia ?? null };
+      }
 
       const ctx = await loadResidenteCtx(tx, tenantId, viewer.residenteId);
       const visible = canResidenteSeeTicket(ctx, {

--- a/apps/api/test/integration/bot-flujo.test.ts
+++ b/apps/api/test/integration/bot-flujo.test.ts
@@ -12,6 +12,7 @@ import {
   ticket,
   unidad,
   vinculoResidente,
+  webhookEvent,
 } from '../../src/db/schema/index.js';
 import { BotService } from '../../src/bot/bot.service.js';
 import { StorageService } from '../../src/storage/storage.service.js';
@@ -268,6 +269,32 @@ describe('comandos (RF-B10)', () => {
     const r = await bot.handle(msg(TEL_UNO, 'se rompió el ascensor, alguna novedad?'));
     expect(r.status).not.toMatch(/^comando-/);
     expect(r.status).not.toBe('sin-reporte');
+  });
+
+  it('todo mensaje atendido queda marcado como procesado (regla 3)', async () => {
+    // `wamid` es la clave de idempotencia: si el evento no se marca, una
+    // reentrega del proveedor vuelve a contestarle al vecino. Cada camino se
+    // acordaba de marcarlo por su cuenta y varios se olvidaban —los comandos,
+    // los mensajes vacíos y los errores de audio quedaban en RECIBIDO—, así que
+    // ahora se marca en un solo lugar. Este test recorre caminos deliberadamente
+    // distintos: comando, cortesía, pregunta ruteada por intención, reporte y
+    // mensaje vacío.
+    const casos = ['ayuda', 'estado', 'gracias', 'hola como andas', 'se rompió la bomba de agua', ''];
+    for (const [i, texto] of casos.entries()) {
+      const m = msg(TEL_UNO, texto);
+      await systemDb.insert(webhookEvent).values({
+        provider: 'telegram',
+        wamid: m.wamid,
+        fromPhone: TEL_UNO,
+        payload: { texto, caso: i },
+      });
+      await bot.handle(m);
+      const [ev] = await systemDb
+        .select({ estado: webhookEvent.estado })
+        .from(webhookEvent)
+        .where(eq(webhookEvent.wamid, m.wamid));
+      expect(ev?.estado, `"${texto}" quedó sin marcar`).toBe('PROCESADO');
+    }
   });
 
   it('todo comando que el menú anuncia, el bot lo acepta', async () => {

--- a/apps/api/test/integration/bot-flujo.test.ts
+++ b/apps/api/test/integration/bot-flujo.test.ts
@@ -250,6 +250,26 @@ describe('comandos (RF-B10)', () => {
     expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
   });
 
+  it('preguntar por los reportes contesta la lista, sin escribir "estado"', async () => {
+    // "¿Cuál fue el último registro?" recibía "no encontré un problema para
+    // registrar": cierto e inútil. Ahora el clasificador dice CONSULTA_ESTADO y
+    // el bot rutea al mismo handler que la palabra escrita exacta.
+    const antes = (await ticketsDe(unConsorcio.id)).length;
+    for (const texto of ['Cuál fue el último registro?', 'cómo vienen mis reclamos?', 'tengo algo pendiente?']) {
+      const r = await bot.handle(msg(TEL_UNO, texto));
+      expect(r.status, texto).toMatch(/^comando-estado/);
+    }
+    expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
+  });
+
+  it('una pregunta que además trae un problema se registra igual', async () => {
+    // Perder un reporte es peor que no contestar una pregunta: si el mensaje
+    // trae las dos cosas, gana el reporte.
+    const r = await bot.handle(msg(TEL_UNO, 'se rompió el ascensor, alguna novedad?'));
+    expect(r.status).not.toMatch(/^comando-/);
+    expect(r.status).not.toBe('sin-reporte');
+  });
+
   it('todo comando que el menú anuncia, el bot lo acepta', async () => {
     // El menú prometía "*estado*" y el set de comandos solo tenía "estados", así
     // que escribir exactamente la palabra que el bot te dice caía en la lista de
@@ -315,7 +335,8 @@ describe('comandos (RF-B10)', () => {
 
   it('si el clasificador no encuentra un reporte, no inventa uno', async () => {
     // El segundo cinturón, para las frases que no están en la lista de cortesías:
-    // el modelo devuelve `es_reporte: false` y el bot lo respeta. Sin esto,
+    // el modelo devuelve una intención distinta de REPORTE y el bot lo respeta.
+    // Sin esto,
     // "No te dije gracias!" terminaba como un ticket de CONDUCTA titulado
     // "Agradecimiento no expresado".
     const antes = (await ticketsDe(unConsorcio.id)).length;

--- a/apps/api/test/integration/bot-flujo.test.ts
+++ b/apps/api/test/integration/bot-flujo.test.ts
@@ -1,0 +1,284 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { InboundMessage } from '@consorciofix/messaging';
+import { systemDb } from '../../src/db/client.js';
+import {
+  clasificacionIa,
+  consorcio,
+  residente,
+  sesionBot,
+  tenant as tenantTable,
+  ticket,
+  unidad,
+  vinculoResidente,
+} from '../../src/db/schema/index.js';
+import { BotService } from '../../src/bot/bot.service.js';
+import { StorageService } from '../../src/storage/storage.service.js';
+
+/**
+ * Flujo del bot (P1 / RF-B01..B07, B10) por su única puerta de entrada:
+ * `BotService.handle`.
+ *
+ * Se llama al service en vez de al webhook porque firmar el payload exige el
+ * secreto del proveedor, que no existe en CI; la cadena firma → webhook → cola
+ * ya está cubierta en `bot-tenant-routing` y en la suite de aislamiento. Lo que
+ * falta cubrir —y es lo que este archivo cubre— es la lógica de conversación:
+ * quién escribe, a qué consorcio pertenece, y qué pasa cuando pertenece a más
+ * de uno. `bot` era el módulo con menos cobertura del repo (10%).
+ *
+ * El clasificador y el embedder son mocks en proceso (AI_PROVIDER por defecto),
+ * así que no hace falta red. `reply()` traga los errores de envío, así que la
+ * ausencia del mock de WhatsApp no altera ningún resultado.
+ */
+const PREFIX = `bot_${Date.now()}_`;
+const tel = (n: number) => `+5498${String(Date.now()).slice(-7)}${String(n).padStart(2, '0')}`;
+
+let bot: BotService;
+
+let tenA: { id: string };
+let tenB: { id: string };
+let c1: { id: string };
+let c2: { id: string };
+let cB: { id: string };
+let u1: { id: string };
+let u2: { id: string };
+let uB: { id: string };
+
+let unConsorcio: { id: string };
+let dosConsorcios: { id: string };
+let sinConsorcio: { id: string };
+let duplicadoA: { id: string };
+let duplicadoB: { id: string };
+
+const TEL_UNO = tel(1);
+const TEL_DOS = tel(2);
+const TEL_SIN = tel(3);
+const TEL_DUP = tel(4);
+const TEL_DESCONOCIDO = tel(9);
+
+let seq = 0;
+function msg(from: string, text: string): InboundMessage {
+  seq += 1;
+  return {
+    wamid: `${PREFIX}wamid_${seq}`,
+    from: from as `+${string}`,
+    kind: 'text',
+    text,
+    receivedAt: new Date(),
+  };
+}
+
+async function ticketsDe(residenteId: string) {
+  return systemDb.select().from(ticket).where(eq(ticket.reportanteId, residenteId));
+}
+
+beforeAll(async () => {
+  bot = new BotService(new StorageService());
+
+  const mkTenant = async (s: string) =>
+    (await systemDb.insert(tenantTable).values({ nombre: `${PREFIX}${s}`, plan: 'basico' }).returning())[0]!;
+  tenA = await mkTenant('A');
+  tenB = await mkTenant('B');
+
+  const mkCons = async (tid: string, s: string) =>
+    (await systemDb.insert(consorcio).values({ tenantId: tid, nombre: `${PREFIX}${s}`, tipo: 'EDIFICIO' }).returning())[0]!;
+  c1 = await mkCons(tenA.id, 'Torre1');
+  c2 = await mkCons(tenA.id, 'Torre2');
+  cB = await mkCons(tenB.id, 'OtraAdmin');
+
+  const mkUni = async (tid: string, cid: string, etiqueta: string) =>
+    (await systemDb.insert(unidad).values({ tenantId: tid, consorcioId: cid, etiqueta }).returning())[0]!;
+  u1 = await mkUni(tenA.id, c1.id, '1A');
+  u2 = await mkUni(tenA.id, c2.id, '2A');
+  uB = await mkUni(tenB.id, cB.id, '9Z');
+
+  const mkResi = async (tid: string, s: string, telefono: string) =>
+    (
+      await systemDb
+        .insert(residente)
+        .values({ tenantId: tid, nombre: `${PREFIX}${s}`, telefonoE164: telefono })
+        .returning()
+    )[0]!;
+  unConsorcio = await mkResi(tenA.id, 'uno', TEL_UNO);
+  dosConsorcios = await mkResi(tenA.id, 'dos', TEL_DOS);
+  sinConsorcio = await mkResi(tenA.id, 'sin', TEL_SIN);
+  // El MISMO teléfono cargado en dos administraciones distintas.
+  duplicadoA = await mkResi(tenA.id, 'dupA', TEL_DUP);
+  duplicadoB = await mkResi(tenB.id, 'dupB', TEL_DUP);
+
+  const vinc = (tid: string, rid: string, uid: string, activo = true) =>
+    systemDb.insert(vinculoResidente).values({ tenantId: tid, residenteId: rid, unidadId: uid, rol: 'PROPIETARIO', activo });
+  await vinc(tenA.id, unConsorcio.id, u1.id);
+  await vinc(tenA.id, dosConsorcios.id, u1.id);
+  await vinc(tenA.id, dosConsorcios.id, u2.id);
+  await vinc(tenA.id, duplicadoA.id, u1.id);
+  await vinc(tenB.id, duplicadoB.id, uB.id);
+  // `sinConsorcio` tiene un vínculo DADO DE BAJA: existe la fila, pero no cuenta.
+  await vinc(tenA.id, sinConsorcio.id, u1.id, false);
+}, 120_000);
+
+afterAll(async () => {
+  await systemDb.delete(tenantTable).where(inArray(tenantTable.id, [tenA.id, tenB.id]));
+});
+
+beforeEach(async () => {
+  // Las sesiones viven por teléfono y sobreviven al caso anterior.
+  await systemDb.delete(sesionBot).where(inArray(sesionBot.telefonoE164, [TEL_UNO, TEL_DOS, TEL_SIN, TEL_DUP]));
+});
+
+describe('identificación de quién escribe', () => {
+  it('un teléfono desconocido no crea nada', async () => {
+    const r = await bot.handle(msg(TEL_DESCONOCIDO, 'se rompió el ascensor'));
+    expect(r.status).toBe('unregistered');
+    expect(r.ticketId).toBeUndefined();
+  });
+
+  it('un teléfono cargado en dos administraciones NO se rutea a ninguna', async () => {
+    // Es la decisión importante: preferir no atender antes que imputarle el
+    // reporte al tenant equivocado, que sería una fuga entre clientes.
+    const r = await bot.handle(msg(TEL_DUP, 'hay una pérdida de agua'));
+    expect(r.status).toBe('ambiguous-tenant');
+    expect(await ticketsDe(duplicadoA.id)).toHaveLength(0);
+    expect(await ticketsDe(duplicadoB.id)).toHaveLength(0);
+  });
+
+  it('un vínculo dado de baja no habilita a reportar', async () => {
+    const r = await bot.handle(msg(TEL_SIN, 'se quemó una luz'));
+    expect(r.status).toBe('no-active-consorcios');
+    expect(await ticketsDe(sinConsorcio.id)).toHaveLength(0);
+  });
+});
+
+describe('residente de un solo consorcio', () => {
+  it('pide confirmación antes de crear el ticket (RF-B06)', async () => {
+    const r = await bot.handle(msg(TEL_UNO, 'se rompió el portón del garage'));
+    expect(r.status).toBe('awaiting-report-confirm');
+    // Nada en la bandeja todavía: el residente tiene que poder corregir.
+    const antes = await ticketsDe(unConsorcio.id);
+    expect(antes).toHaveLength(0);
+  });
+
+  it('al confirmar crea el ticket en su consorcio, con la sugerencia de la IA', async () => {
+    await bot.handle(msg(TEL_UNO, 'se rompió el portón del garage'));
+    const r = await bot.handle(msg(TEL_UNO, 'sí'));
+    expect(r.ticketId).toBeTruthy();
+
+    const t = (await systemDb.select().from(ticket).where(eq(ticket.id, r.ticketId!)))[0]!;
+    expect(t.consorcioId).toBe(c1.id);
+    expect(t.reportanteId).toBe(unConsorcio.id);
+    expect(t.estado).toBe('REGISTRADO');
+    expect(t.tenantId).toBe(tenA.id);
+
+    // Regla 4: la salida del clasificador se persiste como sugerencia.
+    const ia = await systemDb.select().from(clasificacionIa).where(eq(clasificacionIa.ticketId, t.id));
+    expect(ia).toHaveLength(1);
+    expect(ia[0]!.corregidoPorAdmin).toBeNull();
+  });
+
+  it('al rechazar no crea nada y deja la puerta abierta', async () => {
+    await bot.handle(msg(TEL_UNO, 'hay olor a gas en el pasillo'));
+    const r = await bot.handle(msg(TEL_UNO, 'no'));
+    expect(r.status).toBe('report-rejected');
+    expect(r.ticketId).toBeUndefined();
+  });
+
+  it('un texto que no es sí ni no se toma como corrección, no como error', async () => {
+    await bot.handle(msg(TEL_UNO, 'se rompió algo'));
+    // El residente reescribe en vez de contestar sí/no.
+    const r = await bot.handle(msg(TEL_UNO, 'en realidad es la bomba de agua del tanque'));
+    // Vuelve a pedir confirmación sobre la versión corregida, sin descartarla.
+    expect(r.status).toBe('awaiting-report-confirm');
+    const conf = await bot.handle(msg(TEL_UNO, 'dale'));
+    const t = (await systemDb.select().from(ticket).where(eq(ticket.id, conf.ticketId!)))[0]!;
+    expect(t.descripcionNormalizada.toLowerCase()).toContain('bomba');
+  });
+});
+
+describe('residente en varios consorcios (P1 / RF-B02)', () => {
+  it('pregunta a cuál de sus consorcios corresponde', async () => {
+    const r = await bot.handle(msg(TEL_DOS, 'se tapó un desagüe'));
+    expect(r.status).toBe('awaiting-consorcio-choice');
+    expect(await ticketsDe(dosConsorcios.id)).toHaveLength(0);
+  });
+
+  it('una respuesta fuera de rango no elige por él', async () => {
+    await bot.handle(msg(TEL_DOS, 'se tapó un desagüe'));
+    const r = await bot.handle(msg(TEL_DOS, '7'));
+    expect(r.status).toBe('consorcio-choice-invalid');
+    expect(await ticketsDe(dosConsorcios.id)).toHaveLength(0);
+    // Y la sesión sigue viva para reintentar.
+    const sesiones = await systemDb.select().from(sesionBot).where(eq(sesionBot.telefonoE164, TEL_DOS));
+    expect(sesiones).toHaveLength(1);
+  });
+
+  it('elegir la opción 2 imputa el ticket a ESE consorcio, no al otro', async () => {
+    await bot.handle(msg(TEL_DOS, 'el alumbrado del estacionamiento no anda'));
+
+    // Se lee de la sesión qué consorcio quedó en la posición 2, para no depender
+    // del orden en que la query devuelva los vínculos.
+    const sesion = (await systemDb.select().from(sesionBot).where(eq(sesionBot.telefonoE164, TEL_DOS)))[0]!;
+    const opciones = (sesion.estadoFlujo as { options?: Array<{ consorcioId: string }> }).options ?? [];
+    expect(opciones).toHaveLength(2);
+    const segundo = opciones[1]!.consorcioId;
+    const descartado = opciones[0]!.consorcioId;
+
+    const elegido = await bot.handle(msg(TEL_DOS, '2'));
+    // Tras elegir el consorcio, todavía falta confirmar el reporte.
+    expect(elegido.status).toBe('awaiting-report-confirm');
+    const r = await bot.handle(msg(TEL_DOS, 'sí'));
+
+    const t = (await systemDb.select().from(ticket).where(eq(ticket.id, r.ticketId!)))[0]!;
+    expect(t.consorcioId).toBe(segundo);
+    expect(t.consorcioId).not.toBe(descartado);
+    // El texto del reporte no se perdió entre la pregunta y la respuesta.
+    expect(t.descripcionNormalizada.length).toBeGreaterThan(0);
+    // La unidad imputada pertenece al consorcio elegido.
+    if (t.unidadId) {
+      const u = (await systemDb.select().from(unidad).where(eq(unidad.id, t.unidadId)))[0]!;
+      expect(u.consorcioId).toBe(t.consorcioId);
+    }
+    expect([c1.id, c2.id]).toContain(t.consorcioId);
+  });
+});
+
+describe('comandos (RF-B10)', () => {
+  it('"estado" consulta reportes, no crea un ticket titulado "estado"', async () => {
+    const antes = (await ticketsDe(unConsorcio.id)).length;
+    const r = await bot.handle(msg(TEL_UNO, 'estado'));
+    expect(r.status).not.toBe('awaiting-report-confirm');
+    expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
+  });
+
+  it('"ayuda" responde el menú', async () => {
+    const r = await bot.handle(msg(TEL_UNO, 'ayuda'));
+    expect(r.status).toBe('comando-ayuda');
+  });
+
+  it('acepta el comando con barra, como en Telegram', async () => {
+    const r = await bot.handle(msg(TEL_UNO, '/ayuda'));
+    expect(r.status).toBe('comando-ayuda');
+  });
+
+  it('un mensaje vacío no crea un ticket vacío', async () => {
+    const r = await bot.handle(msg(TEL_UNO, '   '));
+    expect(r.status).toBe('empty');
+  });
+});
+
+describe('dedup (RF-B07)', () => {
+  it('ante un reporte casi idéntico ofrece sumar el voto en vez de duplicar', async () => {
+    const texto = 'la luz del palier del primer piso está quemada hace tres días';
+    await bot.handle(msg(TEL_UNO, texto));
+    const primero = await bot.handle(msg(TEL_UNO, 'sí'));
+    expect(primero.ticketId).toBeTruthy();
+
+    // Mismo texto, mismo consorcio: el embedder mock es determinístico.
+    const segundo = await bot.handle(msg(TEL_UNO, texto));
+    expect(segundo.status).toBe('dedup-offered');
+    expect(segundo.ticketId).toBe(primero.ticketId);
+  });
+});
+
+void and;
+void clasificacionIa;

--- a/apps/api/test/integration/bot-flujo.test.ts
+++ b/apps/api/test/integration/bot-flujo.test.ts
@@ -250,6 +250,36 @@ describe('comandos (RF-B10)', () => {
     expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
   });
 
+  it('todo comando que el menú anuncia, el bot lo acepta', async () => {
+    // El menú prometía "*estado*" y el set de comandos solo tenía "estados", así
+    // que escribir exactamente la palabra que el bot te dice caía en la lista de
+    // cortesías: el vecino recibía "cuando necesites algo, contame" en lugar de
+    // sus reportes. Este test lee los comandos del propio texto del menú, así que
+    // agregar una línea al menú sin implementarla vuelve a fallar acá.
+    const enviados: string[] = [];
+    const original = bot['reply'].bind(bot);
+    (bot as unknown as { reply: unknown }).reply = async (to: string, texto: string, ctx: unknown) => {
+      enviados.push(texto);
+      return (original as (a: string, b: string, c: unknown) => Promise<void>)(to, texto, ctx);
+    };
+    try {
+      await bot.handle(msg(TEL_UNO, 'ayuda'));
+      const menu = enviados.find((t) => t.includes('Comandos:'));
+      expect(menu).toBeTruthy();
+      const anunciados = [...menu!.matchAll(/•\s*\*([^*]+)\*/g)].map((m) => m[1]!.trim());
+      expect(anunciados.length).toBeGreaterThan(0);
+      for (const cmd of anunciados) {
+        enviados.length = 0;
+        const r = await bot.handle(msg(TEL_UNO, cmd));
+        expect(r.status, `el menú anuncia "${cmd}" pero el bot no lo trata como comando`).toMatch(
+          /^comando-/,
+        );
+      }
+    } finally {
+      (bot as unknown as { reply: unknown }).reply = original;
+    }
+  });
+
   it('"ayuda" responde el menú', async () => {
     const r = await bot.handle(msg(TEL_UNO, 'ayuda'));
     expect(r.status).toBe('comando-ayuda');
@@ -258,6 +288,43 @@ describe('comandos (RF-B10)', () => {
   it('acepta el comando con barra, como en Telegram', async () => {
     const r = await bot.handle(msg(TEL_UNO, '/ayuda'));
     expect(r.status).toBe('comando-ayuda');
+  });
+
+  it('una cortesía no se convierte en reclamo', async () => {
+    // Un "Gracias" salía como un reporte inventado —"Agujero en el techo del
+    // pasillo", urgencia alta— porque el clasificador está obligado a clasificar
+    // cualquier texto. Se ataja antes de llamar al modelo: además de no ensuciar
+    // la bandeja, ahorra una llamada paga por cada agradecimiento.
+    const antes = (await ticketsDe(unConsorcio.id)).length;
+    for (const texto of ['Gracias', 'gracias!', 'ok', 'dale', 'buenas']) {
+      const r = await bot.handle(msg(TEL_UNO, texto));
+      expect(r.status).toBe('cortesia');
+    }
+    expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
+  });
+
+  it('pero "dale" con una confirmación pendiente SÍ registra el reporte', async () => {
+    // La cortesía se ataja solo cuando no hay sesión abierta: ahí "dale" u "ok"
+    // significan "sí, registralo", y tragárselos dejaría al vecino sin poder
+    // confirmar.
+    await bot.handle(msg(TEL_UNO, 'se rompió la cerradura del portón'));
+    const r = await bot.handle(msg(TEL_UNO, 'dale'));
+    expect(r.status).not.toBe('cortesia');
+    expect(r.ticketId).toBeTruthy();
+  });
+
+  it('si el clasificador no encuentra un reporte, no inventa uno', async () => {
+    // El segundo cinturón, para las frases que no están en la lista de cortesías:
+    // el modelo devuelve `es_reporte: false` y el bot lo respeta. Sin esto,
+    // "No te dije gracias!" terminaba como un ticket de CONDUCTA titulado
+    // "Agradecimiento no expresado".
+    const antes = (await ticketsDe(unConsorcio.id)).length;
+    for (const texto of ['No te dije gracias!', 'hola, todo bien?', 'hola como andas']) {
+      const r = await bot.handle(msg(TEL_UNO, texto));
+      expect(r.status).toBe('sin-reporte');
+      expect(r.ticketId).toBe('');
+    }
+    expect((await ticketsDe(unConsorcio.id)).length).toBe(antes);
   });
 
   it('un mensaje vacío no crea un ticket vacío', async () => {

--- a/apps/api/test/integration/fase5.test.ts
+++ b/apps/api/test/integration/fase5.test.ts
@@ -25,7 +25,9 @@ let ten: { id: string };
 let consA: { id: string }; // consorcio con tickets/costos
 let consB: { id: string }; // consorcio "vacío" para probar filtro
 let uniA: { id: string }; // unidad del residente
+let uniOtra: { id: string }; // otra unidad del MISMO consorcio
 let resi: { id: string };
+let vecinoOtraUnidad: { id: string }; // mismo consorcio, otra unidad
 let ticketComun: { id: string };
 let ticketUnidad: { id: string };
 let ticketConducta: { id: string };
@@ -38,8 +40,13 @@ beforeAll(async () => {
   consA = (await systemDb.insert(consorcio).values({ tenantId: ten.id, nombre: `${PREFIX}A`, tipo: 'EDIFICIO' }).returning())[0]!;
   consB = (await systemDb.insert(consorcio).values({ tenantId: ten.id, nombre: `${PREFIX}B`, tipo: 'EDIFICIO' }).returning())[0]!;
   uniA = (await systemDb.insert(unidad).values({ tenantId: ten.id, consorcioId: consA.id, etiqueta: '4A' }).returning())[0]!;
+  uniOtra = (await systemDb.insert(unidad).values({ tenantId: ten.id, consorcioId: consA.id, etiqueta: '7C' }).returning())[0]!;
   resi = (await systemDb.insert(residente).values({ tenantId: ten.id, nombre: `${PREFIX}resi`, telefonoE164: `+5491${Date.now() % 100000000}` }).returning())[0]!;
-  await systemDb.insert(vinculoResidente).values({ tenantId: ten.id, residenteId: resi.id, unidadId: uniA.id, rol: 'PROPIETARIO', activo: true });
+  vecinoOtraUnidad = (await systemDb.insert(residente).values({ tenantId: ten.id, nombre: `${PREFIX}vecino`, telefonoE164: `+5492${Date.now() % 100000000}` }).returning())[0]!;
+  await systemDb.insert(vinculoResidente).values([
+    { tenantId: ten.id, residenteId: resi.id, unidadId: uniA.id, rol: 'PROPIETARIO', activo: true },
+    { tenantId: ten.id, residenteId: vecinoOtraUnidad.id, unidadId: uniOtra.id, rol: 'PROPIETARIO', activo: true },
+  ]);
 
   // Ticket común con gasto confirmado (visible + costo visible).
   ticketComun = (await systemDb.insert(ticket).values({
@@ -54,7 +61,7 @@ beforeAll(async () => {
   ]);
 
   // Ticket de UNIDAD del residente, con gasto confirmado: visible al ocupante
-  // PERO su costo es privado (no debe aparecer en el feed).
+  // junto con su costo (es quien paga), e invisible para el resto del consorcio.
   ticketUnidad = (await systemDb.insert(ticket).values({
     tenantId: ten.id, consorcioId: consA.id, unidadId: uniA.id,
     tipo: 'INFRAESTRUCTURA', urgencia: 'MEDIA', estado: 'SOLUCIONADO',
@@ -88,11 +95,22 @@ describe('Feed del residente — costos visibles (RF-D05/E02/G10)', () => {
     expect(comun!.costosConfirmados).toEqual([{ moneda: 'ARS', total: 85000 }]);
   });
 
-  it('NO expone el costo de un ticket de UNIDAD (privado), aunque el ocupante vea el ticket', async () => {
+  // Decisión 2026-08-18: antes se esperaba `null` acá también. El costo de un
+  // ticket de unidad no es público, pero el ocupante de esa unidad es justamente
+  // quien paga la reparación: ocultárselo dejaba una factura que el admin cargaba
+  // y nadie más podía ver nunca. G10 protege el costo privado del resto del
+  // consorcio, no del afectado. Ver `canResidenteSeeCosto` en packages/domain.
+  it('expone al ocupante el costo confirmado de su propia unidad', async () => {
     const feed = await new MeService().listFeed(ten.id, resi.id);
     const u = feed.find((t) => t.id === ticketUnidad.id);
-    expect(u).toBeDefined(); // el ocupante VE el ticket
-    expect(u!.costosConfirmados).toBeNull(); // pero NO el costo
+    expect(u).toBeDefined();
+    expect(u!.costosConfirmados).toEqual([{ moneda: 'ARS', total: 12000 }]);
+  });
+
+  it('ese costo de unidad NO se le expone a un vecino de otra unidad', async () => {
+    const feed = await new MeService().listFeed(ten.id, vecinoOtraUnidad.id);
+    // El vecino no ve ni el ticket de la unidad ajena, así que menos su costo.
+    expect(feed.find((t) => t.id === ticketUnidad.id)).toBeUndefined();
   });
 
   it('oculta la identidad del reportante en tickets de conducta (RF-F02)', async () => {

--- a/apps/api/test/integration/logica-negocio.test.ts
+++ b/apps/api/test/integration/logica-negocio.test.ts
@@ -375,6 +375,86 @@ describe('conducta: anonimato del reportante', () => {
     const res = await api('POST', `/tickets/${tConducta}/votes`, 'prop1a');
     expect(res.status).toBe(403);
   });
+
+  it('la sanción se registra contra la unidad SEÑALADA, no contra la del denunciante', async () => {
+    // El defecto: el registro se escribía contra `unidad_id`, y en un ticket
+    // creado por el bot ese campo es la unidad de QUIEN DENUNCIA —el bot imputa
+    // la unidad del que escribe—. Así que un aviso o una sanción le ensuciaba el
+    // historial de convivencia al vecino que reportó.
+    //
+    // El ticket se arma igual que el del bot: `unidad_id` = 2B (el denunciante,
+    // vec2b) y la unidad señalada al validar = 1A. Con los dos campos distintos
+    // el test distingue de verdad; si `unidad_id` ya fuera la acusada, pasaría
+    // también con el código viejo.
+    const r = await api('POST', '/tickets', 'vec2b', {
+      consorcio_id: c1.id,
+      unidad_id: u2b.id,
+      tipo: 'CONDUCTA',
+      titulo: 'Ruidos, reportado desde el 2B',
+      descripcion: 'la del 1A pone música de madrugada',
+    });
+    const idConducta = r.body.id;
+    await api('POST', `/tickets/${idConducta}/transitions`, 'adminA', {
+      to: 'VALIDADO',
+      origen: 'UNIDAD',
+      unidad_reportada_id: u1a.id,
+    });
+
+    const res = await api('POST', `/tickets/${idConducta}/registros-conducta`, 'adminA', {
+      resultado: 'SANCION',
+      detalle: 'segunda vez en el mes',
+    });
+    expect(res.status).toBeLessThan(300);
+    expect(res.body.unidadId).toBe(u1a.id);
+    expect(res.body.unidadId).not.toBe(u2b.id);
+
+    // Aparece en el historial de convivencia de la unidad señalada...
+    const hist = await api('GET', `/unidades/${u1a.id}/historial-conducta`, 'adminA');
+    expect(hist.status).toBe(200);
+    expect(hist.body.some((h: { ticketId: string }) => h.ticketId === idConducta)).toBe(true);
+
+    // ...y NO en el del denunciante, que es el punto del arreglo.
+    const otro = await api('GET', `/unidades/${u2b.id}/historial-conducta`, 'adminA');
+    expect(otro.body.some((h: { ticketId: string }) => h.ticketId === idConducta)).toBe(false);
+  });
+
+  it('no se puede sancionar una conducta sin unidad señalada', async () => {
+    const r = await api('POST', '/tickets', 'vec2b', {
+      consorcio_id: c1.id,
+      unidad_id: u2b.id,
+      tipo: 'CONDUCTA',
+      titulo: 'Sin señalar',
+      descripcion: 'x',
+    });
+    const res = await api('POST', `/tickets/${r.body.id}/registros-conducta`, 'adminA', {
+      resultado: 'AVISO',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('no se puede sancionar un ticket de infraestructura', async () => {
+    const r = await api('POST', '/tickets', 'adminA', {
+      consorcio_id: c1.id,
+      unidad_id: null,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'No es conducta',
+      descripcion: 'x',
+    });
+    const res = await api('POST', `/tickets/${r.body.id}/registros-conducta`, 'adminA', {
+      resultado: 'SANCION',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('el historial de convivencia no lo ve un residente', async () => {
+    const res = await api('GET', `/unidades/${u1a.id}/historial-conducta`, 'prop1a');
+    expect(res.status).toBe(403);
+  });
+
+  it('el historial de convivencia no cruza administraciones', async () => {
+    const res = await api('GET', `/unidades/${u1a.id}/historial-conducta`, 'adminB');
+    expect(res.status === 200 ? res.body.length : 0).toBe(0);
+  });
 });
 
 describe('invitación de inquilino (solo el propietario de esa unidad)', () => {

--- a/apps/api/test/integration/logica-negocio.test.ts
+++ b/apps/api/test/integration/logica-negocio.test.ts
@@ -1,0 +1,565 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { NestFactory } from '@nestjs/core';
+import { json } from 'express';
+import type { INestApplication } from '@nestjs/common';
+import { eq, inArray } from 'drizzle-orm';
+import { AppModule } from '../../src/app.module.js';
+import { systemDb } from '../../src/db/client.js';
+import {
+  consorcio,
+  gasto,
+  residente,
+  tenant as tenantTable,
+  ticket,
+  unidad,
+  usuarioAdmin,
+  vinculoResidente,
+} from '../../src/db/schema/index.js';
+
+/**
+ * Lógica de negocio end-to-end vía HTTP: quién pertenece a qué, qué puede hacer
+ * cada rol dentro de un consorcio, y qué ve cada uno.
+ *
+ * Fija por escrito los hallazgos de la corrida manual del 2026-08-18, que probó
+ * la matriz completa (111 aserciones) contra el entorno local. Los dos defectos
+ * que encontró están cubiertos acá para que no vuelvan:
+ *
+ * 1. `PATCH /consorcios/:id` sobre un consorcio de otra administración
+ *    respondía **200 con body vacío** en vez de 404. No filtraba datos (el
+ *    UPDATE tocaba 0 filas), pero el panel mostraba "guardado" sin guardar.
+ * 2. El costo confirmado de un ticket de UNIDAD era invisible para los
+ *    ocupantes de esa misma unidad — o sea, para quien paga la reparación.
+ *
+ * Escenario: dos administraciones (tenants), tres consorcios, cuatro unidades.
+ * `multi` pertenece a dos consorcios de la misma administración, que es el caso
+ * que rompe cualquier atajo de "un residente = un consorcio".
+ */
+const PREFIX = `log_${Date.now()}_`;
+
+let app: INestApplication;
+let base: string;
+let passwordHash: string;
+
+let tenA: { id: string };
+let tenB: { id: string };
+let c1: { id: string }; // A / edificio
+let c2: { id: string }; // A / barrio
+let c3: { id: string }; // B / edificio
+let u1a: { id: string }; // c1
+let u2b: { id: string }; // c1
+let uL9: { id: string }; // c2
+let u9z: { id: string }; // c3
+
+let propietario1a: { id: string };
+let inquilino1a: { id: string };
+let vecino2b: { id: string };
+let multi: { id: string };
+let ajenoB: { id: string };
+
+let tokens: Record<string, string> = {};
+
+const creados = { tenants: [] as string[] };
+
+async function login(email: string): Promise<string> {
+  const res = await fetch(`${base}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'test1234' }),
+  });
+  const body = (await res.json()) as { accessToken?: string };
+  if (!body.accessToken) throw new Error(`login falló para ${email}: ${JSON.stringify(body)}`);
+  return body.accessToken;
+}
+
+function auth(who: string): Record<string, string> {
+  return { authorization: `Bearer ${tokens[who]}`, 'content-type': 'application/json' };
+}
+
+async function api(
+  method: string,
+  path: string,
+  who: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers: auth(who),
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const txt = await res.text();
+  let parsed: unknown = null;
+  try {
+    parsed = txt ? JSON.parse(txt) : null;
+  } catch {
+    parsed = txt;
+  }
+  return { status: res.status, body: parsed };
+}
+
+let telSeq = 0;
+function tel(): string {
+  telSeq += 1;
+  return `+549${String(Date.now()).slice(-8)}${String(telSeq).padStart(2, '0')}`;
+}
+
+beforeAll(async () => {
+  const { PasswordService } = await import('../../src/auth/password.service.js');
+  passwordHash = await new PasswordService().hash('test1234');
+
+  const mkTenant = async (slug: string) =>
+    (await systemDb.insert(tenantTable).values({ nombre: `${PREFIX}${slug}`, plan: 'basico' }).returning())[0]!;
+  tenA = await mkTenant('A');
+  tenB = await mkTenant('B');
+  creados.tenants.push(tenA.id, tenB.id);
+
+  const mkCons = async (tid: string, slug: string, tipo: 'EDIFICIO' | 'BARRIO') =>
+    (await systemDb.insert(consorcio).values({ tenantId: tid, nombre: `${PREFIX}${slug}`, tipo }).returning())[0]!;
+  c1 = await mkCons(tenA.id, 'c1', 'EDIFICIO');
+  c2 = await mkCons(tenA.id, 'c2', 'BARRIO');
+  c3 = await mkCons(tenB.id, 'c3', 'EDIFICIO');
+
+  const mkUni = async (tid: string, cid: string, etiqueta: string) =>
+    (await systemDb.insert(unidad).values({ tenantId: tid, consorcioId: cid, etiqueta }).returning())[0]!;
+  u1a = await mkUni(tenA.id, c1.id, '1A');
+  u2b = await mkUni(tenA.id, c1.id, '2B');
+  uL9 = await mkUni(tenA.id, c2.id, 'Lote9');
+  u9z = await mkUni(tenB.id, c3.id, '9Z');
+
+  const mkResi = async (tid: string, slug: string) =>
+    (
+      await systemDb
+        .insert(residente)
+        .values({
+          tenantId: tid,
+          nombre: `${PREFIX}${slug}`,
+          email: `${PREFIX}${slug}@test.dev`,
+          passwordHash,
+          telefonoE164: tel(),
+        })
+        .returning()
+    )[0]!;
+  propietario1a = await mkResi(tenA.id, 'prop1a');
+  inquilino1a = await mkResi(tenA.id, 'inq1a');
+  vecino2b = await mkResi(tenA.id, 'vec2b');
+  multi = await mkResi(tenA.id, 'multi');
+  ajenoB = await mkResi(tenB.id, 'ajenoB');
+
+  const vincular = (tid: string, rid: string, uid: string, rol: 'PROPIETARIO' | 'INQUILINO') =>
+    systemDb.insert(vinculoResidente).values({ tenantId: tid, residenteId: rid, unidadId: uid, rol, activo: true });
+  await vincular(tenA.id, propietario1a.id, u1a.id, 'PROPIETARIO');
+  await vincular(tenA.id, inquilino1a.id, u1a.id, 'INQUILINO');
+  await vincular(tenA.id, vecino2b.id, u2b.id, 'PROPIETARIO');
+  await vincular(tenA.id, multi.id, u1a.id, 'PROPIETARIO');
+  await vincular(tenA.id, multi.id, uL9.id, 'PROPIETARIO'); // segundo consorcio
+  await vincular(tenB.id, ajenoB.id, u9z.id, 'PROPIETARIO');
+
+  const mkAdmin = async (tid: string | null, slug: string, rol: 'ADMIN' | 'SUPER_ADMIN') =>
+    (
+      await systemDb
+        .insert(usuarioAdmin)
+        .values({
+          tenantId: tid,
+          email: `${PREFIX}${slug}@test.dev`,
+          passwordHash,
+          rol,
+          nombre: `${PREFIX}${slug}`,
+        })
+        .returning()
+    )[0]!;
+  await mkAdmin(tenA.id, 'adminA', 'ADMIN');
+  await mkAdmin(tenB.id, 'adminB', 'ADMIN');
+
+  app = await NestFactory.create(AppModule, { logger: false });
+  app.use(json({ verify: (req, _res, buf) => { (req as unknown as { rawBody?: Buffer }).rawBody = buf; } }));
+  await app.listen(0);
+  base = await app.getUrl().then((u) => u.replace('[::1]', '127.0.0.1'));
+
+  // El login está rate-limited: una sola pasada, en serie, y se reusan tokens.
+  for (const slug of ['adminA', 'adminB', 'prop1a', 'inq1a', 'vec2b', 'multi', 'ajenoB']) {
+    tokens[slug] = await login(`${PREFIX}${slug}@test.dev`);
+  }
+}, 120_000);
+
+afterAll(async () => {
+  await app?.close();
+  if (creados.tenants.length) {
+    await systemDb.delete(tenantTable).where(inArray(tenantTable.id, creados.tenants));
+  }
+});
+
+describe('pertenencia a consorcios', () => {
+  it('un residente en dos consorcios de la misma administración ve ambos vínculos', async () => {
+    const res = await api('GET', '/me/vinculos', 'multi');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const consorcios = new Set(res.body.map((v: { consorcioId?: string }) => v.consorcioId));
+    expect(consorcios.has(c1.id)).toBe(true);
+    expect(consorcios.has(c2.id)).toBe(true);
+  });
+
+  it('un residente con un solo vínculo no ve más que el suyo', async () => {
+    const res = await api('GET', '/me/vinculos', 'prop1a');
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('puede reportar en un consorcio donde tiene vínculo', async () => {
+    const res = await api('POST', '/tickets', 'multi', {
+      consorcio_id: c2.id,
+      unidad_id: uL9.id,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'Poda del lote',
+      descripcion: 'pasto alto',
+    });
+    expect(res.status).toBeLessThan(300);
+  });
+
+  it('no puede reportar en otro consorcio de su misma administración', async () => {
+    const res = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c2.id,
+      unidad_id: uL9.id,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'Intruso',
+      descripcion: 'x',
+    });
+    expect([403, 404]).toContain(res.status);
+  });
+
+  it('no puede imputar una unidad que pertenece a otro consorcio', async () => {
+    const res = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: uL9.id,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'Unidad ajena',
+      descripcion: 'x',
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('visibilidad por unidad dentro del mismo consorcio', () => {
+  let tUnidad: string;
+  let tComun: string;
+
+  beforeAll(async () => {
+    const a = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'INFRAESTRUCTURA',
+      origen_sugerido: 'UNIDAD',
+      titulo: 'Pérdida en el baño',
+      descripcion: 'gotea',
+    });
+    tUnidad = a.body.id;
+    const b = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: null,
+      tipo: 'INFRAESTRUCTURA',
+      origen_sugerido: 'ESPACIO_COMUN',
+      titulo: 'Luz del hall',
+      descripcion: 'quemada',
+    });
+    tComun = b.body.id;
+    await api('POST', `/tickets/${tUnidad}/transitions`, 'adminA', { to: 'VALIDADO', origen: 'UNIDAD' });
+    await api('POST', `/tickets/${tComun}/transitions`, 'adminA', { to: 'VALIDADO', origen: 'ESPACIO_COMUN' });
+  }, 60_000);
+
+  it('el ticket de una unidad lo ven sus ocupantes (propietario e inquilino)', async () => {
+    expect((await api('GET', `/tickets/${tUnidad}`, 'prop1a')).status).toBe(200);
+    expect((await api('GET', `/tickets/${tUnidad}`, 'inq1a')).status).toBe(200);
+  });
+
+  it('el vecino de otra unidad del mismo consorcio recibe 404, no 403', async () => {
+    // 403 confirmaría que el ticket existe. La ausencia debe ser indistinguible.
+    expect((await api('GET', `/tickets/${tUnidad}`, 'vec2b')).status).toBe(404);
+  });
+
+  it('el ticket de espacio común lo ve todo el consorcio', async () => {
+    expect((await api('GET', `/tickets/${tComun}`, 'vec2b')).status).toBe(200);
+    expect((await api('GET', `/tickets/${tComun}`, 'inq1a')).status).toBe(200);
+  });
+
+  it('nada de esto se ve desde otra administración', async () => {
+    expect((await api('GET', `/tickets/${tComun}`, 'ajenoB')).status).toBe(404);
+    expect((await api('GET', `/tickets/${tUnidad}`, 'ajenoB')).status).toBe(404);
+  });
+
+  it('el costo confirmado de la propia unidad es visible a sus ocupantes', async () => {
+    // El defecto original: el propietario que paga al plomero recibía 404 al
+    // pedir el monto de su propia reparación.
+    const g = await api('POST', `/tickets/${tUnidad}/gastos`, 'adminA', {
+      monto: 9999,
+      descripcion: 'Plomero',
+      estado: 'CONFIRMADO',
+    });
+    expect(g.status).toBeLessThan(300);
+
+    const propio = await api('GET', `/tickets/${tUnidad}/gastos`, 'prop1a');
+    expect(propio.status).toBe(200);
+    expect(propio.body).toHaveLength(1);
+    const inquilino = await api('GET', `/tickets/${tUnidad}/gastos`, 'inq1a');
+    expect(inquilino.body).toHaveLength(1);
+  });
+
+  it('ese mismo costo sigue oculto para el resto del consorcio', async () => {
+    const vecino = await api('GET', `/tickets/${tUnidad}/gastos`, 'vec2b');
+    expect(vecino.status).toBe(404);
+  });
+
+  it('el borrador nunca se publica, ni al ocupante de la unidad', async () => {
+    await api('POST', `/tickets/${tUnidad}/gastos`, 'adminA', {
+      monto: 123456,
+      descripcion: 'presupuesto tentativo',
+      estado: 'BORRADOR',
+    });
+    const propio = await api('GET', `/tickets/${tUnidad}/gastos`, 'prop1a');
+    expect(propio.body.every((g: { estado: string }) => g.estado === 'CONFIRMADO')).toBe(true);
+  });
+});
+
+describe('conducta: anonimato del reportante', () => {
+  let tConducta: string;
+
+  beforeAll(async () => {
+    const r = await api('POST', '/tickets', 'vec2b', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'CONDUCTA',
+      titulo: 'Ruidos molestos',
+      descripcion: 'música a las 3am',
+    });
+    tConducta = r.body.id;
+    await api('POST', `/tickets/${tConducta}/transitions`, 'adminA', {
+      to: 'VALIDADO',
+      origen: 'UNIDAD',
+      unidad_reportada_id: u1a.id,
+    });
+  }, 60_000);
+
+  it('el acusado ve la denuncia pero no quién la hizo', async () => {
+    const res = await api('GET', `/tickets/${tConducta}`, 'prop1a');
+    expect(res.status).toBe(200);
+    expect(res.body.reportanteId ?? null).toBeNull();
+  });
+
+  it('el admin sí ve al reportante', async () => {
+    const res = await api('GET', `/tickets/${tConducta}`, 'adminA');
+    expect(res.body.reportanteId).toBe(vecino2b.id);
+  });
+
+  it('el historial no le filtra al acusado la nota del admin', async () => {
+    const res = await api('GET', `/tickets/${tConducta}/historial`, 'prop1a');
+    expect(res.status).toBe(200);
+    expect(res.body.every((h: { nota: unknown; autorTipo: unknown }) => h.nota == null && h.autorTipo == null)).toBe(true);
+  });
+
+  it('validar una conducta exige la unidad reportada', async () => {
+    const r = await api('POST', '/tickets', 'vec2b', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'CONDUCTA',
+      titulo: 'Otra conducta',
+      descripcion: 'x',
+    });
+    const sin = await api('POST', `/tickets/${r.body.id}/transitions`, 'adminA', { to: 'VALIDADO', origen: 'UNIDAD' });
+    expect(sin.status).toBeGreaterThanOrEqual(400);
+    const cruzada = await api('POST', `/tickets/${r.body.id}/transitions`, 'adminA', {
+      to: 'VALIDADO',
+      origen: 'UNIDAD',
+      unidad_reportada_id: u9z.id, // unidad de OTRA administración
+    });
+    expect(cruzada.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('una conducta no se vota', async () => {
+    const res = await api('POST', `/tickets/${tConducta}/votes`, 'prop1a');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('invitación de inquilino (solo el propietario de esa unidad)', () => {
+  it('el propietario puede invitar y el invitado queda operativo', async () => {
+    const email = `${PREFIX}invitado@test.dev`;
+    const res = await api('POST', '/residentes/invite-inquilino', 'prop1a', {
+      unidad_id: u1a.id,
+      nombre: `${PREFIX}invitado`,
+      telefono_e164: tel(),
+      email,
+      password: 'test1234',
+    });
+    expect(res.status).toBeLessThan(300);
+
+    tokens.invitado = await login(email);
+    const vinculos = await api('GET', '/me/vinculos', 'invitado');
+    expect(vinculos.body).toHaveLength(1);
+    expect(vinculos.body[0].rol).toBe('INQUILINO');
+  });
+
+  it('un inquilino no puede invitar a otro inquilino', async () => {
+    const res = await api('POST', '/residentes/invite-inquilino', 'inq1a', {
+      unidad_id: u1a.id,
+      nombre: `${PREFIX}no`,
+      telefono_e164: tel(),
+      email: `${PREFIX}no1@test.dev`,
+      password: 'test1234',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('el propietario de otra unidad del mismo consorcio no puede invitar a esa unidad', async () => {
+    const res = await api('POST', '/residentes/invite-inquilino', 'vec2b', {
+      unidad_id: u1a.id,
+      nombre: `${PREFIX}no`,
+      telefono_e164: tel(),
+      email: `${PREFIX}no2@test.dev`,
+      password: 'test1234',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('un residente de otra administración no puede invitar acá', async () => {
+    const res = await api('POST', '/residentes/invite-inquilino', 'ajenoB', {
+      unidad_id: u1a.id,
+      nombre: `${PREFIX}no`,
+      telefono_e164: tel(),
+      email: `${PREFIX}no3@test.dev`,
+      password: 'test1234',
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('aislamiento entre administraciones', () => {
+  it('editar un consorcio ajeno devuelve 404, no 200 con body vacío', async () => {
+    // El UPDATE ya tocaba 0 filas, pero devolvía 200 y el panel mostraba
+    // "guardado" sin haber guardado nada.
+    const res = await api('PATCH', `/consorcios/${c1.id}`, 'adminB', { nombre: 'renombrado por otro tenant' });
+    expect(res.status).toBe(404);
+    const sigue = await systemDb.select().from(consorcio).where(eq(consorcio.id, c1.id));
+    expect(sigue[0]!.nombre).toBe(`${PREFIX}c1`);
+  });
+
+  it('el listado de consorcios no cruza administraciones', async () => {
+    const res = await api('GET', '/consorcios', 'adminB');
+    const ids = res.body.map((c: { id: string }) => c.id);
+    expect(ids).not.toContain(c1.id);
+    expect(ids).toContain(c3.id);
+  });
+
+  it('no se puede crear una unidad en el consorcio de otra administración', async () => {
+    const res = await api('POST', '/unidades', 'adminB', { consorcio_id: c1.id, etiqueta: 'PWN' });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('no se puede vincular un residente ajeno a una unidad propia', async () => {
+    const res = await api('POST', '/vinculos', 'adminB', {
+      residente_id: propietario1a.id,
+      unidad_id: u9z.id,
+      rol: 'PROPIETARIO',
+    });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('un ADMIN no puede crear administraciones (es privilegio de SUPER_ADMIN)', async () => {
+    expect((await api('GET', '/tenants', 'adminA')).status).toBe(403);
+    expect((await api('POST', '/tenants', 'adminA', { nombre: 'x' })).status).toBe(403);
+  });
+});
+
+describe('gates de rol', () => {
+  const soloAdmin = ['/tickets', '/residentes', '/consorcios', '/vinculos', '/categorias', '/admin/metrics', '/admin/audit-log', '/admin/notificaciones'];
+  for (const path of soloAdmin) {
+    it(`un residente no entra a ${path}`, async () => {
+      expect((await api('GET', path, 'prop1a')).status).toBe(403);
+    });
+  }
+
+  const soloResidente = ['/me/tickets', '/me/vinculos'];
+  for (const path of soloResidente) {
+    it(`un admin no entra a ${path}`, async () => {
+      expect((await api('GET', path, 'adminA')).status).toBe(403);
+    });
+  }
+
+  it('un residente no puede transicionar un ticket', async () => {
+    const r = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'para transicionar',
+      descripcion: 'x',
+    });
+    const res = await api('POST', `/tickets/${r.body.id}/transitions`, 'prop1a', { to: 'VALIDADO' });
+    expect(res.status).toBe(403);
+  });
+
+  it('un admin no puede votar', async () => {
+    const r = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: null,
+      tipo: 'INFRAESTRUCTURA',
+      origen_sugerido: 'ESPACIO_COMUN',
+      titulo: 'votable',
+      descripcion: 'x',
+    });
+    expect((await api('POST', `/tickets/${r.body.id}/votes`, 'adminA')).status).toBe(403);
+  });
+});
+
+describe('máquina de estados', () => {
+  let t: string;
+  beforeAll(async () => {
+    const r = await api('POST', '/tickets', 'adminA', {
+      consorcio_id: c1.id,
+      unidad_id: null,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'fsm',
+      descripcion: 'x',
+    });
+    t = r.body.id;
+  }, 30_000);
+
+  it('no se puede saltar de REGISTRADO a SOLUCIONADO', async () => {
+    expect((await api('POST', `/tickets/${t}/transitions`, 'adminA', { to: 'SOLUCIONADO' })).status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('el camino feliz avanza y no admite reapertura', async () => {
+    expect((await api('POST', `/tickets/${t}/transitions`, 'adminA', { to: 'VALIDADO', origen: 'ESPACIO_COMUN' })).status).toBeLessThan(300);
+    expect((await api('POST', `/tickets/${t}/transitions`, 'adminA', { to: 'SOLUCIONADO' })).status).toBeLessThan(300);
+    // Sin reapertura (ADR-002): si el problema reaparece se crea un ticket nuevo.
+    expect((await api('POST', `/tickets/${t}/transitions`, 'adminA', { to: 'VALIDADO' })).status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('un admin de otra administración no puede transicionar', async () => {
+    const r = await api('POST', '/tickets', 'adminA', {
+      consorcio_id: c1.id,
+      unidad_id: null,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'fsm ajeno',
+      descripcion: 'x',
+    });
+    expect((await api('POST', `/tickets/${r.body.id}/transitions`, 'adminB', { to: 'VALIDADO' })).status).toBe(404);
+  });
+});
+
+describe('idempotencia', () => {
+  it('el mismo client_generated_id no duplica el ticket', async () => {
+    const body = {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'INFRAESTRUCTURA',
+      titulo: 'idempotente',
+      descripcion: 'x',
+      client_generated_id: crypto.randomUUID(),
+    };
+    const a = await api('POST', '/tickets', 'prop1a', body);
+    const b = await api('POST', '/tickets', 'prop1a', body);
+    expect(a.body.id).toBe(b.body.id);
+    const filas = await systemDb.select().from(ticket).where(eq(ticket.clientGeneratedId, body.client_generated_id));
+    expect(filas).toHaveLength(1);
+  });
+});
+
+// `gasto` se elimina en cascada con el tenant; la referencia explícita evita que
+// el import quede sin usar si alguien recorta un caso.
+void gasto;

--- a/apps/api/test/integration/logica-negocio.test.ts
+++ b/apps/api/test/integration/logica-negocio.test.ts
@@ -347,6 +347,32 @@ describe('conducta: anonimato del reportante', () => {
     expect(res.body.reportanteId).toBe(vecino2b.id);
   });
 
+  it('la nota interna tampoco se filtra en un ticket de infraestructura', async () => {
+    // El panel la pide como "NOTA INTERNA — contexto para el equipo". Antes se
+    // ocultaba solo en CONDUCTA, así que en infraestructura el residente la leía
+    // y el rótulo mentía.
+    const r = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'INFRAESTRUCTURA',
+      origen_sugerido: 'ESPACIO_COMUN',
+      titulo: 'Luz del hall, con nota',
+      descripcion: 'quemada',
+    });
+    await api('POST', `/tickets/${r.body.id}/transitions`, 'adminA', {
+      to: 'VALIDADO',
+      origen: 'ESPACIO_COMUN',
+      nota: 'ojo que este vecino reclama por todo',
+    });
+
+    const comoAdmin = await api('GET', `/tickets/${r.body.id}/historial`, 'adminA');
+    expect(comoAdmin.body.some((h: { nota?: string | null }) => h.nota?.includes('reclama'))).toBe(true);
+
+    const comoVecino = await api('GET', `/tickets/${r.body.id}/historial`, 'prop1a');
+    expect(comoVecino.status).toBe(200);
+    expect(comoVecino.body.every((h: { nota?: string | null }) => h.nota == null)).toBe(true);
+  });
+
   it('el historial no le filtra al acusado la nota del admin', async () => {
     const res = await api('GET', `/tickets/${tConducta}/historial`, 'prop1a');
     expect(res.status).toBe(200);

--- a/apps/api/test/integration/logica-negocio.test.ts
+++ b/apps/api/test/integration/logica-negocio.test.ts
@@ -11,6 +11,7 @@ import {
   gasto,
   residente,
   tenant as tenantTable,
+  notificacion,
   ticket,
   unidad,
   usuarioAdmin,
@@ -345,6 +346,43 @@ describe('conducta: anonimato del reportante', () => {
   it('el admin sí ve al reportante', async () => {
     const res = await api('GET', `/tickets/${tConducta}`, 'adminA');
     expect(res.body.reportanteId).toBe(vecino2b.id);
+  });
+
+  it('la nota interna no viaja en el aviso que recibe el vecino', async () => {
+    // Las tres plantillas la interpolaban, así que escribir "ojo que este vecino
+    // reclama por todo" se lo mandaba por WhatsApp — y no solo al que reportó: la
+    // notificación va también a todos los que votaron el ticket.
+    const secreto = 'ojo-que-este-vecino-reclama-por-todo';
+    const r = await api('POST', '/tickets', 'prop1a', {
+      consorcio_id: c1.id,
+      unidad_id: u1a.id,
+      tipo: 'INFRAESTRUCTURA',
+      origen_sugerido: 'ESPACIO_COMUN',
+      titulo: 'Con nota que no debe salir',
+      descripcion: 'x',
+    });
+    await api('POST', `/tickets/${r.body.id}/transitions`, 'adminA', {
+      to: 'VALIDADO',
+      origen: 'ESPACIO_COMUN',
+      nota: secreto,
+    });
+
+    // La notificación se encola de forma asíncrona (setImmediate), así que se le
+    // da una vuelta al event loop antes de mirar.
+    await new Promise((resolver) => setTimeout(resolver, 400));
+    const avisos = await systemDb
+      .select({ plantilla: notificacion.plantilla })
+      .from(notificacion)
+      .where(eq(notificacion.ticketId, r.body.id));
+
+    // Lo que se guarda es la plantilla, no el texto: alcanza con verificar que
+    // ninguna plantilla del catálogo interpole la nota.
+    const { NOTIFICATION_TEMPLATES } = await import('../../src/notifications/templates.js');
+    for (const tpl of Object.values(NOTIFICATION_TEMPLATES)) {
+      const cuerpo = tpl.body({ short: 'abc12345', nota: secreto });
+      expect(cuerpo).not.toContain(secreto);
+    }
+    expect(avisos.length).toBeGreaterThanOrEqual(0);
   });
 
   it('la nota interna tampoco se filtra en un ticket de infraestructura', async () => {

--- a/apps/api/test/integration/pendientes.test.ts
+++ b/apps/api/test/integration/pendientes.test.ts
@@ -237,6 +237,35 @@ describe('RF-A05 — importación masiva de residentes', () => {
     expect(cargados.length).toBe(3);
   });
 
+  it('la prueba no cuenta dos veces la misma unidad nueva', async () => {
+    // Dos ocupantes de la MISMA unidad que no existe: la unidad a crear es una,
+    // no dos. Antes la prueba la contaba por fila, así que una planilla con
+    // propietario + inquilino por unidad informaba el doble de unidades y el
+    // admin decidía sobre ese número inflado.
+    const csvDosPorUnidad = [
+      'nombre,telefono,email,unidad,rol',
+      'Propietaria Nueva,+549119998001,,7K,PROPIETARIO',
+      'Inquilino Nuevo,+549119998002,,7K,INQUILINO',
+    ].join('\n');
+    const res = await fetch(`${base}/import/residentes`, {
+      method: 'POST',
+      headers: auth(tokenAdmin),
+      body: JSON.stringify({ consorcio_id: cons.id, csv: csvDosPorUnidad, dry_run: true, crear_unidades: true }),
+    });
+    expect(res.status).toBe(201);
+    const r = (await res.json()) as { unidadesCreadas: string[]; validas: number; dryRun: boolean };
+    expect(r.dryRun).toBe(true);
+    expect(r.validas).toBe(2);
+    expect(r.unidadesCreadas).toEqual(['7K']);
+
+    // Y no escribió nada, que es el punto de la prueba.
+    const nada = await systemDb
+      .select({ id: residente.id })
+      .from(residente)
+      .where(and(eq(residente.tenantId, ten.id), like(residente.telefonoE164, '+54911999800%')));
+    expect(nada).toHaveLength(0);
+  });
+
   it('un residente no puede importar', async () => {
     const res = await fetch(`${base}/import/residentes`, {
       method: 'POST',

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -25,6 +25,21 @@ export default defineConfig({
   ],
   test: {
     include: ['test/integration/**/*.test.ts'],
+    // El proveedor de IA se fija en `mock` a propósito.
+    //
+    // Sin esto los tests heredan el `AI_PROVIDER` del `.env` de quien los corre:
+    // con una API key puesta, seis casos del bot fallaban —el clasificador real
+    // normaliza los textos distinto que el stub y el umbral de dedup pasa de 0.55
+    // a 0.85— mientras en CI, que no tiene key, pasaban. Un test que depende de
+    // quién lo ejecuta no prueba nada. Y de paso: cada corrida completa dejaría
+    // de ser gratis y dependería de que la red ande.
+    env: {
+      AI_PROVIDER: 'mock',
+      AI_CLASSIFIER_PROVIDER: 'mock',
+      AI_EMBEDDER_PROVIDER: 'mock',
+      AI_TRANSCRIBER_PROVIDER: 'mock',
+      AI_VISION_PROVIDER: 'mock',
+    },
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],

--- a/apps/api/vitest.isolation.config.ts
+++ b/apps/api/vitest.isolation.config.ts
@@ -6,6 +6,21 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['test/isolation/**/*.test.ts'],
+    // El proveedor de IA se fija en `mock` a propósito.
+    //
+    // Sin esto los tests heredan el `AI_PROVIDER` del `.env` de quien los corre:
+    // con una API key puesta, seis casos del bot fallaban —el clasificador real
+    // normaliza los textos distinto que el stub y el umbral de dedup pasa de 0.55
+    // a 0.85— mientras en CI, que no tiene key, pasaban. Un test que depende de
+    // quién lo ejecuta no prueba nada. Y de paso: cada corrida completa dejaría
+    // de ser gratis y dependería de que la red ande.
+    env: {
+      AI_PROVIDER: 'mock',
+      AI_CLASSIFIER_PROVIDER: 'mock',
+      AI_EMBEDDER_PROVIDER: 'mock',
+      AI_TRANSCRIBER_PROVIDER: 'mock',
+      AI_VISION_PROVIDER: 'mock',
+    },
     testTimeout: 30000,
     hookTimeout: 30000,
     pool: 'forks',

--- a/apps/mobile/app/(tabs)/feed.tsx
+++ b/apps/mobile/app/(tabs)/feed.tsx
@@ -164,6 +164,20 @@ export default function FeedScreen(): JSX.Element {
             </View>
             <Text style={styles.cardTitle}>{item.titulo}</Text>
             <Text style={styles.cardDesc} numberOfLines={2}>{item.descripcionNormalizada}</Text>
+            {/* RF-D05/E02/G10: el costo confirmado del arreglo. Es la propuesta
+                de valor del producto —el vecino ve en qué se gastó la plata— y
+                la app no lo mostraba en ninguna pantalla. `null` significa que
+                no corresponde verlo (unidad ajena o conducta), así que no se
+                renderiza nada; una lista vacía es "visible, sin costo todavía". */}
+            {item.costosConfirmados && item.costosConfirmados.length > 0 && (
+              <View style={styles.costos}>
+                {item.costosConfirmados.map((c) => (
+                  <Text key={c.moneda} style={styles.costoText}>
+                    Costo del arreglo: {c.moneda} {c.total.toLocaleString('es-AR', { minimumFractionDigits: 2 })}
+                  </Text>
+                ))}
+              </View>
+            )}
             <View style={styles.cardFooter}>
               <Text style={styles.cardMeta}>
                 {ESTADO_LABEL[item.estado]} · {relativeTime(item.createdAt)}
@@ -214,6 +228,14 @@ const styles = StyleSheet.create({
   cardChips: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
   cardTitle: { fontSize: 15.5, fontWeight: '600', color: COLORS.ink, letterSpacing: -0.2 },
   cardDesc: { color: COLORS.ink3, fontSize: 13, lineHeight: 18 },
+  costos: {
+    backgroundColor: COLORS.bg,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 9,
+    marginBottom: 8,
+  },
+  costoText: { color: COLORS.ink2, fontSize: 12.5, fontWeight: '600' },
   cardFooter: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   cardMeta: { color: COLORS.ink3, fontSize: 11.5 },
   votes: { flexDirection: 'row', alignItems: 'baseline', gap: 4 },

--- a/apps/mobile/app/(tabs)/nuevo.tsx
+++ b/apps/mobile/app/(tabs)/nuevo.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  AppState,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -14,7 +15,7 @@ import { Card, CardLabel } from '../../src/components/Card.js';
 import { MobileHeader } from '../../src/components/Header.js';
 import { createTicket, misVinculos, type Vinculo } from '../../src/lib/api.js';
 import { COLORS, RADIUS } from '../../src/lib/colors.js';
-import { enqueue, readQueue, syncQueue, type PendingReport } from '../../src/lib/offline-queue.js';
+import { descartar, enqueue, readQueue, syncQueue, type PendingReport } from '../../src/lib/offline-queue.js';
 
 function uuid(): string {
   const rand = () => Math.floor(Math.random() * 0x10000).toString(16).padStart(4, '0');
@@ -33,23 +34,53 @@ export default function NuevoScreen(): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [pending, setPending] = useState<PendingReport[]>([]);
 
-  useEffect(() => {
-    readQueue().then(setPending);
-  }, []);
+  // La pantalla prometía "se enviará cuando vuelva la red" y no había nada que
+  // lo hiciera: `syncQueue` solo corría si el vecino apretaba el botón. Ahora se
+  // intenta al abrir la pantalla y cada vez que la app vuelve al frente, que es
+  // cuando en la práctica se recuperó la señal. Se hace con `AppState`, que ya
+  // viene en react-native, en vez de sumar netinfo como dependencia: escuchar la
+  // conectividad de verdad es mejor, pero no puedo probarlo sin un dispositivo y
+  // prefiero algo que sé que funciona a algo que parece funcionar.
+  const [sincronizando, setSincronizando] = useState(false);
 
-  async function onSync() {
-    setBusy(true);
-    setError(null);
-    setInfo(null);
+  const sincronizar = useCallback(async (silencioso: boolean) => {
+    const cola = await readQueue();
+    const hayQueIntentar = cola.some((i) => !i.rechazadoDefinitivamente);
+    if (!hayQueIntentar) {
+      setPending(cola);
+      if (!silencioso) setInfo('No hay nada pendiente de enviar.');
+      return;
+    }
+    setSincronizando(true);
     try {
       const r = await syncQueue();
       setPending(await readQueue());
-      setInfo(`Sincronizadas ${r.synced}, fallaron ${r.failed}, quedan ${r.remaining}.`);
+      if (!silencioso || r.enviados > 0) {
+        setInfo(
+          r.enviados > 0
+            ? `Se enviaron ${r.enviados} reporte${r.enviados === 1 ? '' : 's'}.` +
+                (r.pendientes > 0 ? ` Quedan ${r.pendientes}.` : '')
+            : `No se pudo enviar todavía. Quedan ${r.pendientes} en espera.`,
+        );
+      }
     } catch (e) {
-      setError((e as Error).message);
+      if (!silencioso) setError((e as Error).message);
     } finally {
-      setBusy(false);
+      setSincronizando(false);
     }
+  }, []);
+
+  useEffect(() => {
+    void sincronizar(true);
+    const sub = AppState.addEventListener('change', (estado) => {
+      if (estado === 'active') void sincronizar(true);
+    });
+    return () => sub.remove();
+  }, [sincronizar]);
+
+  async function onDescartar(id: string) {
+    await descartar(id);
+    setPending(await readQueue());
   }
 
   useEffect(() => {
@@ -73,6 +104,9 @@ export default function NuevoScreen(): JSX.Element {
     () => vinculos.find((v) => v.consorcioId === consorcioId) ?? null,
     [vinculos, consorcioId],
   );
+
+  const enEspera = useMemo(() => pending.filter((p) => !p.rechazadoDefinitivamente), [pending]);
+  const rechazados = useMemo(() => pending.filter((p) => p.rechazadoDefinitivamente), [pending]);
 
   async function onSubmit() {
     if (!consorcioId || !titulo.trim() || !descripcion.trim()) {
@@ -212,14 +246,33 @@ export default function NuevoScreen(): JSX.Element {
           </View>
         )}
 
-        {pending.length > 0 && (
+        {enEspera.length > 0 && (
           <View style={styles.pendingBox}>
-            <Text style={styles.pendingTitle}>{pending.length} reporte{pending.length === 1 ? '' : 's'} pendiente{pending.length === 1 ? '' : 's'} de sincronizar</Text>
-            <Pressable onPress={onSync} disabled={busy} style={({ pressed }) => [styles.syncBtn, pressed && { opacity: 0.7 }]}>
-              <Text style={styles.syncBtnText}>Reintentar ahora</Text>
+            <Text style={styles.pendingTitle}>
+              {enEspera.length} reporte{enEspera.length === 1 ? '' : 's'} esperando conexión. Se
+              {enEspera.length === 1 ? ' va' : ' van'} a enviar solo{enEspera.length === 1 ? '' : 's'}.
+            </Text>
+            <Pressable
+              onPress={() => void sincronizar(false)}
+              disabled={sincronizando}
+              style={({ pressed }) => [styles.syncBtn, (pressed || sincronizando) && { opacity: 0.7 }]}
+            >
+              <Text style={styles.syncBtnText}>{sincronizando ? 'Enviando…' : 'Enviar ahora'}</Text>
             </Pressable>
           </View>
         )}
+
+        {/* Rechazados: no se reintentan más y no se borran solos. El vecino
+            escribió ese texto; que desaparezca sin decirle nada es peor. */}
+        {rechazados.map((r) => (
+          <View key={r.id} style={styles.rejectedBox}>
+            <Text style={styles.rejectedTitle}>No se pudo registrar “{r.body.titulo}”</Text>
+            <Text style={styles.rejectedReason}>{r.lastError ?? 'La administración lo rechazó.'}</Text>
+            <Pressable onPress={() => void onDescartar(r.id)} style={({ pressed }) => [styles.discardBtn, pressed && { opacity: 0.7 }]}>
+              <Text style={styles.discardText}>Descartar</Text>
+            </Pressable>
+          </View>
+        ))}
 
         {info && <Text style={styles.info}>{info}</Text>}
         {error && <Text style={styles.error}>{error}</Text>}
@@ -300,6 +353,14 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.blue700,
   },
   syncBtnText: { color: 'white', fontWeight: '600', fontSize: 12 },
+  rejectedBox: {
+    backgroundColor: '#fef2f2', borderColor: '#fecaca', borderWidth: 1,
+    padding: 12, borderRadius: 10, marginTop: 10,
+  },
+  rejectedTitle: { color: '#991b1b', fontSize: 12.5, fontWeight: '700' },
+  rejectedReason: { color: '#b91c1c', fontSize: 12, marginTop: 3 },
+  discardBtn: { alignSelf: 'flex-start', marginTop: 8, paddingHorizontal: 10, paddingVertical: 6, borderRadius: 8, borderWidth: 1, borderColor: '#fecaca' },
+  discardText: { color: '#991b1b', fontWeight: '600', fontSize: 12 },
   button: {
     backgroundColor: COLORS.blue700, paddingVertical: 14,
     borderRadius: RADIUS.base, alignItems: 'center', marginTop: 16,

--- a/apps/mobile/app/(tabs)/perfil.tsx
+++ b/apps/mobile/app/(tabs)/perfil.tsx
@@ -1,11 +1,11 @@
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Card, CardLabel } from '../../src/components/Card.js';
 import { Chip } from '../../src/components/Chip.js';
 import { MobileHeader } from '../../src/components/Header.js';
 import { useAuth } from '../../src/lib/auth-ctx.js';
-import { misVinculos, type Vinculo } from '../../src/lib/api.js';
+import { inviteInquilino, misVinculos, type Vinculo } from '../../src/lib/api.js';
 import { COLORS, RADIUS } from '../../src/lib/colors.js';
 
 const ROL_LABEL: Record<Vinculo['rol'], string> = {
@@ -18,9 +18,55 @@ export default function PerfilScreen(): JSX.Element {
   const router = useRouter();
   const [vinculos, setVinculos] = useState<Vinculo[]>([]);
 
-  useEffect(() => {
+  // Alta de inquilino por el propietario. Solo se ofrece para las unidades donde
+  // el usuario ES propietario: en las demás la API responde 403, y mostrar el
+  // formulario ahí sería ofrecer algo que no puede terminar bien.
+  const propias = vinculos.filter((v) => v.rol === 'PROPIETARIO');
+  const [invitarEn, setInvitarEn] = useState<Vinculo | null>(null);
+  const [invNombre, setInvNombre] = useState('');
+  const [invTel, setInvTel] = useState('+54');
+  const [invEmail, setInvEmail] = useState('');
+  const [invPass, setInvPass] = useState('');
+  const [invBusy, setInvBusy] = useState(false);
+  const [invError, setInvError] = useState<string | null>(null);
+  const [invOk, setInvOk] = useState<string | null>(null);
+
+  function cargarVinculos() {
     if (user?.kind === 'RESIDENTE') misVinculos().then(setVinculos).catch(() => {});
-  }, [user?.kind]);
+  }
+  useEffect(cargarVinculos, [user?.kind]);
+
+  function cerrarInvitacion() {
+    setInvitarEn(null);
+    setInvNombre('');
+    setInvTel('+54');
+    setInvEmail('');
+    setInvPass('');
+    setInvError(null);
+  }
+
+  async function onInvitar() {
+    if (!invitarEn) return;
+    setInvBusy(true);
+    setInvError(null);
+    setInvOk(null);
+    try {
+      await inviteInquilino({
+        unidad_id: invitarEn.unidadId,
+        nombre: invNombre.trim(),
+        telefono_e164: invTel.trim(),
+        email: invEmail.trim(),
+        password: invPass,
+      });
+      setInvOk(`Listo. ${invNombre.trim()} ya puede entrar con ${invEmail.trim()}.`);
+      cerrarInvitacion();
+      cargarVinculos();
+    } catch (e) {
+      setInvError((e as Error).message);
+    } finally {
+      setInvBusy(false);
+    }
+  }
 
   async function onLogout() {
     await logout();
@@ -33,7 +79,7 @@ export default function PerfilScreen(): JSX.Element {
     <View style={styles.wrap}>
       <MobileHeader title="Perfil" />
 
-      <View style={styles.body}>
+      <ScrollView contentContainerStyle={styles.body}>
         <View style={styles.avatar}>
           <Text style={styles.avatarText}>{initials}</Text>
         </View>
@@ -64,13 +110,95 @@ export default function PerfilScreen(): JSX.Element {
           </Card>
         )}
 
+        {propias.length > 0 && (
+          <Card style={styles.section}>
+            <CardLabel>Inquilinos</CardLabel>
+            <Text style={styles.hint}>
+              Como propietario/a podés dar de alta al inquilino de tu unidad. Va a poder reportar
+              y ver los reportes de esa unidad con su propio usuario.
+            </Text>
+            {invOk && <Text style={styles.ok}>{invOk}</Text>}
+
+            {!invitarEn ? (
+              propias.map((v) => (
+                <Pressable
+                  key={v.vinculoId}
+                  style={({ pressed }) => [styles.inviteBtn, pressed && { opacity: 0.85 }]}
+                  onPress={() => {
+                    setInvOk(null);
+                    setInvitarEn(v);
+                  }}
+                >
+                  <Text style={styles.inviteText}>
+                    Dar de alta un inquilino en {v.unidadEtiqueta}
+                  </Text>
+                </Pressable>
+              ))
+            ) : (
+              <View>
+                <Text style={styles.formTitle}>
+                  Inquilino de {invitarEn.unidadEtiqueta} · {invitarEn.consorcioNombre}
+                </Text>
+                <TextInput
+                  style={styles.input}
+                  placeholder="Nombre y apellido"
+                  placeholderTextColor={COLORS.ink3}
+                  value={invNombre}
+                  onChangeText={setInvNombre}
+                />
+                <TextInput
+                  style={styles.input}
+                  placeholder="Teléfono (+5491100000000)"
+                  placeholderTextColor={COLORS.ink3}
+                  value={invTel}
+                  onChangeText={setInvTel}
+                  keyboardType="phone-pad"
+                />
+                <TextInput
+                  style={styles.input}
+                  placeholder="Email"
+                  placeholderTextColor={COLORS.ink3}
+                  value={invEmail}
+                  onChangeText={setInvEmail}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                <TextInput
+                  style={styles.input}
+                  placeholder="Contraseña inicial (mínimo 6)"
+                  placeholderTextColor={COLORS.ink3}
+                  value={invPass}
+                  onChangeText={setInvPass}
+                  secureTextEntry
+                />
+                {invError && <Text style={styles.error}>{invError}</Text>}
+                <View style={styles.formActions}>
+                  <Pressable
+                    style={({ pressed }) => [styles.inviteBtn, { flex: 1 }, pressed && { opacity: 0.85 }]}
+                    onPress={onInvitar}
+                    disabled={invBusy || !invNombre || !invEmail || invPass.length < 6}
+                  >
+                    <Text style={styles.inviteText}>{invBusy ? 'Dando de alta…' : 'Dar de alta'}</Text>
+                  </Pressable>
+                  <Pressable
+                    style={({ pressed }) => [styles.cancelBtn, pressed && { opacity: 0.85 }]}
+                    onPress={cerrarInvitacion}
+                  >
+                    <Text style={styles.cancelText}>Cancelar</Text>
+                  </Pressable>
+                </View>
+              </View>
+            )}
+          </Card>
+        )}
+
         <Pressable
           style={({ pressed }) => [styles.logoutBtn, pressed && { opacity: 0.85 }]}
           onPress={onLogout}
         >
           <Text style={styles.logoutText}>Cerrar sesión</Text>
         </Pressable>
-      </View>
+      </ScrollView>
     </View>
   );
 }
@@ -110,4 +238,24 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   logoutText: { color: COLORS.critical, fontWeight: '600', fontSize: 14 },
+  hint: { fontSize: 12.5, color: COLORS.ink3, lineHeight: 18, marginBottom: 10 },
+  formTitle: { fontSize: 13, fontWeight: '600', color: COLORS.ink, marginBottom: 8 },
+  input: {
+    borderWidth: 1, borderColor: COLORS.line2, borderRadius: RADIUS.base,
+    paddingHorizontal: 11, paddingVertical: 10, marginBottom: 8,
+    fontSize: 14, color: COLORS.ink, backgroundColor: 'white',
+  },
+  formActions: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  inviteBtn: {
+    backgroundColor: COLORS.blue700, borderRadius: RADIUS.base,
+    paddingVertical: 12, paddingHorizontal: 14, alignItems: 'center', marginTop: 4,
+  },
+  inviteText: { color: 'white', fontWeight: '600', fontSize: 13.5 },
+  cancelBtn: {
+    borderWidth: 1, borderColor: COLORS.line2, borderRadius: RADIUS.base,
+    paddingVertical: 12, paddingHorizontal: 14, alignItems: 'center', marginTop: 4,
+  },
+  cancelText: { color: COLORS.ink2, fontWeight: '600', fontSize: 13.5 },
+  ok: { color: COLORS.resolved, fontSize: 12.5, marginBottom: 8 },
+  error: { color: COLORS.critical, fontSize: 12.5, marginBottom: 8 },
 });

--- a/apps/mobile/app/tickets/[id].tsx
+++ b/apps/mobile/app/tickets/[id].tsx
@@ -82,7 +82,12 @@ export default function TicketDetailScreen(): JSX.Element {
     );
   }
 
-  const canVote = t.estado !== 'DESCARTADO' && t.estado !== 'SOLUCIONADO';
+  // Las conductas NO se votan: son una denuncia entre vecinos, no un reclamo
+  // colectivo que gane prioridad por apoyo (RF-F02 / P5). La API las rechaza con
+  // 403, y acá se mostraba el botón igual: el denunciado veía "Sumar voto" sobre
+  // la denuncia hecha en su contra y el único resultado posible era un error.
+  const esConducta = t.tipo === 'CONDUCTA';
+  const canVote = !esConducta && t.estado !== 'DESCARTADO' && t.estado !== 'SOLUCIONADO';
   const { step, status } = stepFromEstado(t);
 
   return (
@@ -125,7 +130,17 @@ export default function TicketDetailScreen(): JSX.Element {
         <Stepper current={step} status={status} />
       </Card>
 
-      {/* Voto */}
+      {/* Voto. En conducta la tarjeta entera no aplica: el contador siempre va a
+          ser 0 y "vecinos afectados" no significa nada en una denuncia. */}
+      {esConducta ? (
+        <Card style={{ marginTop: 12 }}>
+          <CardLabel>Reporte de conducta</CardLabel>
+          <Text style={styles.desc}>
+            Lo maneja la administración en privado. Quien lo reportó queda anónimo, y estos
+            reportes no se votan.
+          </Text>
+        </Card>
+      ) : (
       <Card style={{ marginTop: 12 }}>
         <View style={styles.voteRow}>
           <View>
@@ -149,6 +164,30 @@ export default function TicketDetailScreen(): JSX.Element {
           )}
         </View>
       </Card>
+      )}
+
+      {/* Costo del arreglo (RF-D05/E02/G10). `null` = no corresponde mostrarlo:
+          es un ticket de otra unidad o una conducta. Lista vacía = todavía no se
+          cargó ningún costo, y decirlo es mejor que no mostrar la sección: el
+          vecino se pregunta cuánto salió. */}
+      {t.costosConfirmados && (
+        <Card style={{ marginTop: 12 }}>
+          <CardLabel>Costo del arreglo</CardLabel>
+          {t.costosConfirmados.length === 0 ? (
+            <Text style={styles.desc}>
+              La administración todavía no cargó el costo.
+            </Text>
+          ) : (
+            t.costosConfirmados.map((c) => (
+              <Meta
+                key={c.moneda}
+                k={c.moneda}
+                v={c.total.toLocaleString('es-AR', { minimumFractionDigits: 2 })}
+              />
+            ))
+          )}
+        </Card>
+      )}
 
       {/* Fechas */}
       <Card style={{ marginTop: 12 }}>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,9 +10,9 @@
     "web": "expo start --web",
     "build": "echo 'mobile build runs via EAS; placeholder'",
     "dev": "expo start",
-    "lint": "eslint src",
+    "lint": "eslint src app",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "echo 'mobile tests added in Phase 4'",
+    "test": "vitest run --passWithNoTests",
     "clean": "rm -rf .expo dist .turbo"
   },
   "dependencies": {
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/react": "~18.2.0",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -93,6 +93,17 @@ export interface FeedTicket {
   votosCount: number;
   reportanteId: string | null;
   voted: boolean;
+  /**
+   * Costos confirmados del arreglo, por moneda (RF-D05/E02/G10).
+   *
+   * Tres estados distintos y los tres significan algo:
+   *   `null` → no corresponde mostrarlo (unidad ajena o conducta);
+   *   `[]`   → es visible pero todavía no se cargó ningún costo;
+   *   con datos → el gasto confirmado.
+   * La transparencia de costos es la propuesta de valor del producto y la app
+   * no mostraba este campo en ninguna pantalla.
+   */
+  costosConfirmados: Array<{ moneda: string; total: number }> | null;
   createdAt: string;
   validatedAt: string | null;
   solucionadoAt: string | null;
@@ -171,4 +182,26 @@ export function registerPushToken(token: string): Promise<{ ok: boolean }> {
     method: 'POST',
     body: JSON.stringify({ token }),
   });
+}
+
+/**
+ * El propietario da de alta a su inquilino desde la app (CLAUDE.md: vínculo
+ * unidad-residente). Crea el residente y el vínculo INQUILINO en un solo paso.
+ *
+ * La API verifica que quien invita sea PROPIETARIO activo de esa unidad: un
+ * inquilino no puede invitar, y un propietario no puede invitar a una unidad que
+ * no es suya. El endpoint existía y ninguna pantalla lo llamaba.
+ */
+export interface InviteInquilinoBody {
+  unidad_id: string;
+  nombre: string;
+  telefono_e164: string;
+  email: string;
+  password: string;
+}
+
+export function inviteInquilino(
+  body: InviteInquilinoBody,
+): Promise<{ id: string; email: string; vinculo: 'INQUILINO'; unidad_id: string }> {
+  return apiFetch('/residentes/invite-inquilino', { method: 'POST', body: JSON.stringify(body) });
 }

--- a/apps/mobile/src/lib/offline-queue.test.ts
+++ b/apps/mobile/src/lib/offline-queue.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * Cola offline (RF-E05 / RNF-11).
+ *
+ * Es la pieza donde un bug se traduce en un reporte perdido: el vecino escribe
+ * lo que le pasa sin señal, la app promete que lo va a enviar, y si la cola se
+ * equivoca ese texto no llega nunca. Antes no había ningún test.
+ *
+ * `createTicket` se mockea para poder simular las tres respuestas que importan:
+ * éxito, error de red (se reintenta) y rechazo del servidor (no se reintenta).
+ */
+const createTicket = vi.fn();
+vi.mock('./api.js', async () => {
+  // ApiError es real: la clasificación de errores depende de su `status`.
+  class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  }
+  return { ApiError, createTicket: (...args: unknown[]) => createTicket(...args) };
+});
+
+const { ApiError } = await import('./api.js');
+const { enqueue, readQueue, syncQueue, descartar, clearQueue } = await import('./offline-queue.js');
+
+function reporte(id: string, titulo = 'Se rompió algo') {
+  return {
+    consorcio_id: 'c-1',
+    unidad_id: 'u-1',
+    tipo: 'INFRAESTRUCTURA' as const,
+    titulo,
+    descripcion: 'detalle del problema',
+    client_generated_id: id,
+  };
+}
+
+beforeEach(async () => {
+  (AsyncStorage as unknown as { __reset: () => void }).__reset();
+  createTicket.mockReset();
+  await clearQueue();
+});
+
+describe('encolado', () => {
+  it('guarda el reporte y lo conserva entre lecturas', async () => {
+    await enqueue(reporte('id-1'));
+    const cola = await readQueue();
+    expect(cola).toHaveLength(1);
+    expect(cola[0]!.body.titulo).toBe('Se rompió algo');
+    expect(cola[0]!.attempts).toBe(0);
+  });
+
+  it('encolar dos veces el mismo client_generated_id no duplica', async () => {
+    // Es la misma clave de idempotencia que usa la API: si la app reintenta el
+    // encolado, no puede terminar con dos reportes del mismo hecho.
+    await enqueue(reporte('id-1'));
+    await enqueue(reporte('id-1', 'texto corregido'));
+    const cola = await readQueue();
+    expect(cola).toHaveLength(1);
+    expect(cola[0]!.body.titulo).toBe('texto corregido');
+  });
+});
+
+describe('sincronización', () => {
+  it('lo que entra bien se saca de la cola', async () => {
+    await enqueue(reporte('id-1'));
+    createTicket.mockResolvedValueOnce({ id: 'ticket-1' });
+
+    const r = await syncQueue();
+    expect(r.enviados).toBe(1);
+    expect(r.pendientes).toBe(0);
+    expect(await readQueue()).toHaveLength(0);
+  });
+
+  it('un error de red deja el reporte para reintentar', async () => {
+    await enqueue(reporte('id-1'));
+    createTicket.mockRejectedValueOnce(new Error('Network request failed'));
+
+    const r = await syncQueue();
+    expect(r.enviados).toBe(0);
+    expect(r.reintentables).toBe(1);
+    expect(r.rechazados).toBe(0);
+
+    const cola = await readQueue();
+    expect(cola).toHaveLength(1);
+    expect(cola[0]!.attempts).toBe(1);
+    expect(cola[0]!.rechazadoDefinitivamente).toBeUndefined();
+  });
+
+  it('un 5xx también se reintenta: el servidor puede recuperarse', async () => {
+    await enqueue(reporte('id-1'));
+    createTicket.mockRejectedValueOnce(new ApiError(503, 'service unavailable'));
+
+    const r = await syncQueue();
+    expect(r.reintentables).toBe(1);
+    expect((await readQueue())[0]!.rechazadoDefinitivamente).toBeUndefined();
+  });
+
+  it('un 403 no se reintenta más, pero tampoco se borra solo', async () => {
+    // El caso real: al vecino le dieron de baja el vínculo mientras estaba sin
+    // señal. Antes esto se reencolaba para siempre y hacía fallar todas las
+    // sincronizaciones siguientes.
+    await enqueue(reporte('id-1'));
+    createTicket.mockRejectedValueOnce(new ApiError(403, 'sin vínculo activo en ese consorcio'));
+
+    const r = await syncQueue();
+    expect(r.rechazados).toBe(1);
+    expect(r.reintentables).toBe(0);
+
+    const cola = await readQueue();
+    expect(cola).toHaveLength(1);
+    expect(cola[0]!.rechazadoDefinitivamente).toBe(true);
+    expect(cola[0]!.lastError).toContain('vínculo');
+
+    // Y en la pasada siguiente ni se intenta.
+    createTicket.mockClear();
+    const r2 = await syncQueue();
+    expect(createTicket).not.toHaveBeenCalled();
+    expect(r2.enviados).toBe(0);
+    expect(r2.rechazados).toBe(1);
+  });
+
+  it('429 y 408 se tratan como transitorios, no como rechazo', async () => {
+    await enqueue(reporte('id-1'));
+    await enqueue(reporte('id-2'));
+    createTicket
+      .mockRejectedValueOnce(new ApiError(429, 'demasiados intentos'))
+      .mockRejectedValueOnce(new ApiError(408, 'timeout'));
+
+    const r = await syncQueue();
+    expect(r.rechazados).toBe(0);
+    expect(r.reintentables).toBe(2);
+  });
+
+  it('un reporte rechazado no bloquea a los demás', async () => {
+    await enqueue(reporte('malo'));
+    await enqueue(reporte('bueno'));
+    createTicket
+      .mockRejectedValueOnce(new ApiError(400, 'unidad inexistente'))
+      .mockResolvedValueOnce({ id: 'ticket-ok' });
+
+    const r = await syncQueue();
+    expect(r.enviados).toBe(1);
+    expect(r.rechazados).toBe(1);
+
+    const cola = await readQueue();
+    expect(cola).toHaveLength(1);
+    expect(cola[0]!.id).toBe('malo');
+  });
+
+  it('el vecino puede descartar un reporte rechazado', async () => {
+    await enqueue(reporte('id-1'));
+    createTicket.mockRejectedValueOnce(new ApiError(400, 'no va'));
+    await syncQueue();
+
+    await descartar('id-1');
+    expect(await readQueue()).toHaveLength(0);
+  });
+
+  it('con la cola vacía no llama a la API', async () => {
+    const r = await syncQueue();
+    expect(createTicket).not.toHaveBeenCalled();
+    expect(r).toEqual({ enviados: 0, reintentables: 0, rechazados: 0, pendientes: 0 });
+  });
+
+  it('reintentar algo que en realidad sí entró no crea un segundo ticket', async () => {
+    // La API deduplica por client_generated_id, así que el reintento devuelve el
+    // mismo ticket. Lo que le toca a la cola es sacarlo, no encolarlo de nuevo.
+    await enqueue(reporte('id-1'));
+    createTicket.mockResolvedValueOnce({ id: 'ticket-ya-existia' });
+
+    await syncQueue();
+    expect(createTicket).toHaveBeenCalledTimes(1);
+    expect(createTicket.mock.calls[0]![0]).toMatchObject({ client_generated_id: 'id-1' });
+    expect(await readQueue()).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/lib/offline-queue.ts
+++ b/apps/mobile/src/lib/offline-queue.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { createTicket, type CreateTicketBody } from './api.js';
+import { ApiError, createTicket, type CreateTicketBody } from './api.js';
 
 const QUEUE_KEY = 'cfx.offline-queue';
 
@@ -9,6 +9,18 @@ export interface PendingReport {
   attempts: number;
   lastError?: string;
   queuedAt: string;
+  /**
+   * El servidor rechazó el reporte de forma definitiva (4xx que no es 408 ni
+   * 429). Reintentarlo es inútil: la respuesta va a ser la misma siempre.
+   *
+   * Antes esto no existía y `syncQueue` reencolaba cualquier fallo, así que un
+   * reporte rechazado —por ejemplo el de un residente al que le dieron de baja
+   * el vínculo mientras estaba sin señal— se quedaba en la cola para siempre y
+   * hacía fallar todas las sincronizaciones siguientes. Tampoco se descarta
+   * solo: queda visible con el motivo, porque el vecino escribió ese texto y
+   * borrárselo en silencio es peor que mostrarle que no entró.
+   */
+  rechazadoDefinitivamente?: boolean;
 }
 
 export async function readQueue(): Promise<PendingReport[]> {
@@ -47,34 +59,74 @@ export async function removeFromQueue(id: string): Promise<void> {
 }
 
 /**
- * Intenta sincronizar todo el queue. Cada éxito quita del queue.
- * Cada fallo incrementa attempts y persiste lastError.
- * Devuelve resumen para mostrar al usuario.
+ * ¿Vale la pena reintentar este error?
+ *
+ * Un 4xx significa que el pedido está mal y va a seguir estando mal: falta un
+ * vínculo, la unidad no es de ese consorcio, el token venció. Las excepciones
+ * son 408 (timeout) y 429 (rate limit), que sí son transitorios. Cualquier otra
+ * cosa —error de red, 5xx— se reintenta.
  */
-export async function syncQueue(): Promise<{ synced: number; failed: number; remaining: number }> {
-  const items = await readQueue();
-  if (items.length === 0) return { synced: 0, failed: 0, remaining: 0 };
+function esDefinitivo(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status === 408 || err.status === 429) return false;
+  return err.status >= 400 && err.status < 500;
+}
 
-  let synced = 0;
-  let failed = 0;
+export interface ResultadoSync {
+  enviados: number;
+  reintentables: number;
+  rechazados: number;
+  pendientes: number;
+}
+
+/**
+ * Intenta sincronizar la cola completa.
+ *
+ * Los reportes ya rechazados definitivamente no se vuelven a intentar, así que
+ * uno roto no bloquea a los demás. El resto se reintenta: la API deduplica por
+ * `client_generated_id`, así que reenviar algo que en realidad sí había entrado
+ * no crea un segundo ticket.
+ */
+export async function syncQueue(): Promise<ResultadoSync> {
+  const items = await readQueue();
+  if (items.length === 0) return { enviados: 0, reintentables: 0, rechazados: 0, pendientes: 0 };
+
+  let enviados = 0;
+  let reintentables = 0;
   const next: PendingReport[] = [];
 
   for (const item of items) {
+    if (item.rechazadoDefinitivamente) {
+      next.push(item);
+      continue;
+    }
     try {
       await createTicket(item.body);
-      synced++;
+      enviados++;
     } catch (err) {
-      failed++;
+      const definitivo = esDefinitivo(err);
+      if (!definitivo) reintentables++;
       next.push({
         ...item,
         attempts: item.attempts + 1,
         lastError: (err as Error).message,
+        ...(definitivo ? { rechazadoDefinitivamente: true } : {}),
       });
     }
   }
 
   await writeQueue(next);
-  return { synced, failed, remaining: next.length };
+  return {
+    enviados,
+    reintentables,
+    rechazados: next.filter((i) => i.rechazadoDefinitivamente).length,
+    pendientes: next.length,
+  };
+}
+
+/** Descarta un reporte que el servidor rechazó y el vecino decidió soltar. */
+export async function descartar(id: string): Promise<void> {
+  await removeFromQueue(id);
 }
 
 export async function clearQueue(): Promise<void> {

--- a/apps/mobile/test/stubs/async-storage.ts
+++ b/apps/mobile/test/stubs/async-storage.ts
@@ -1,0 +1,18 @@
+/** AsyncStorage en memoria. Misma API que la real para lo que usa la app. */
+const store = new Map<string, string>();
+
+export default {
+  async getItem(k: string): Promise<string | null> {
+    return store.has(k) ? store.get(k)! : null;
+  },
+  async setItem(k: string, v: string): Promise<void> {
+    store.set(k, v);
+  },
+  async removeItem(k: string): Promise<void> {
+    store.delete(k);
+  },
+  /** Solo para los tests: deja el almacenamiento limpio entre casos. */
+  __reset(): void {
+    store.clear();
+  },
+};

--- a/apps/mobile/test/stubs/expo-constants.ts
+++ b/apps/mobile/test/stubs/expo-constants.ts
@@ -1,0 +1,2 @@
+/** `expo-constants` no existe fuera de la app; solo se lee `expoConfig.extra`. */
+export default { expoConfig: { extra: { apiUrl: 'http://test.local' } } };

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+/**
+ * Tests de la lógica pura de la app, corriendo en Node.
+ *
+ * No se levanta React Native: lo que se prueba es la cola offline, que es la
+ * pieza donde un bug se traduce en un reporte perdido. AsyncStorage y expo se
+ * resuelven a stubs por alias — son las únicas dependencias nativas que toca
+ * este módulo, y stubearlas es más simple y más rápido que arrastrar el preset
+ * de jest de Expo entero.
+ *
+ * Hasta ahora `pnpm test` corría `echo 'mobile tests added in Phase 4'`, así que
+ * el paquete reportaba verde en CI sin ejecutar nada.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@react-native-async-storage/async-storage': path.resolve(__dirname, 'test/stubs/async-storage.ts'),
+      'expo-constants': path.resolve(__dirname, 'test/stubs/expo-constants.ts'),
+    },
+  },
+});

--- a/docs/05-plan-desarrollo-claude-code.md
+++ b/docs/05-plan-desarrollo-claude-code.md
@@ -121,18 +121,19 @@
 
 ---
 
-## Estado real al 2026-08-18
+## Estado real al 2026-08-20
 
 Verificado ejecutando, no leyendo. Lo que sigue vale más que las tildes de las tablas de arriba.
 
-Actualizado el 2026-08-18, después de probar la lógica completa en runtime (PR #39).
+Actualizado el 2026-08-20, después de conectar la API key de OpenAI y correr el
+clasificador contra el dataset y contra Telegram real.
 
 | Fase | Estado | Qué falta concretamente |
 |---|---|---|
 | 0 — Fundaciones | ✅ | Branch protection en `main` (tarea 0.3) nunca se configuró |
 | 1 — Dominio, RBAC, tickets | ✅ | Nada de alcance vigente. RF-D03/D04/D07 superados por ADR-002 |
 | 2 — WhatsApp texto | ✅ | RF-B06 (resumen + confirmación) cerrado. Notificaciones con cola durable, backoff y reaper; la ventana de 24 h se calcula con `residente.ultimo_inbound_at` |
-| 3 — IA real | 🟡 | **Solo falta poner la API key.** Dataset de 302 casos, `ai:eval` con umbrales y persistencia de sugerencias listos. La telemetría de costo (3.8) ya se muestra en Resumen y en el detalle del ticket. Queda una bandeja dedicada de baja confianza (3.7): hoy la confianza real se ve por ticket, pero no hay cola de revisión filtrada |
+| 3 — IA real | 🟡 | **La key está puesta y el clasificador corre contra el modelo real.** Dataset de 322 casos; `intencion` 100 %, `tipo` 98,7 %, `origen` 96,3 % pasan los umbrales; `categoria` 87,6 % queda abajo del 90 % por deuda de taxonomía (falta la categoría `gas`, y el dataset etiqueta a veces por síntoma y a veces por causa raíz) — es decisión de producto, no de prompt. Queda la bandeja dedicada de baja confianza (3.7): hoy la confianza se ve por ticket, pero no hay cola de revisión filtrada. Transcripción de audio y visión siguen sin ejercitarse contra el proveedor real |
 | 4 — App móvil | 🟡 | Push notifications (`expo-notifications` no está ni en dependencias) y E2E Maestro. `costosConfirmados` ya se muestra en el feed y en el detalle |
 | 5 — Conductas y costos | ✅ | Nada. RF-F01 cerrado con la opción A |
 | 6 — Hardening | ❌ | Sin arrancar, salvo el gate de cobertura y el upgrade de drizzle que ya se hicieron |
@@ -147,14 +148,22 @@ de tenant. `webhook_event` tampoco tiene RLS, pero ahí es correcto: guarda el
 payload crudo del proveedor *antes* de saber a qué tenant corresponde. Falta la
 política de `sesion_bot` y su test en `test:isolation`.
 
+**Medición del clasificador (2026-08-20).** La urgencia tiene ~3 puntos de
+variación entre corridas idénticas con `temperature: 0` (medido: tres corridas,
+mismo prompt, 59,0 / 61,8 / 59,0 %), mientras las otras cuatro tareas se mueven
+menos de 1 punto. Cualquier afirmación sobre urgencia necesita tres corridas y
+reportar rango; para el resto una corrida alcanza. El detalle está en
+`packages/ai/src/prompts/CHANGELOG.md`.
+
 **Cobertura medida el 2026-08-18** (integración, por módulo): global 72,5 %.
 `webhooks` 14 % es el más bajo con diferencia — la firma HMAC y el parseo de
 payloads casi no se ejercitan por HTTP. Después `notifications` 62 % y
 `core-admin` 63 %. `bot` subió de 10 % a 66,6 % con la suite `bot-flujo`.
 
-**Lo que más conviene atacar ahora**, en orden: la key de IA y su corrida de
-`ai:eval` (desbloquea el capítulo de validación), la política RLS de `sesion_bot`,
-y la cobertura de `webhooks`.
+**Lo que más conviene atacar ahora**, en orden: la política RLS de `sesion_bot`
+(rompe la regla 1), la cobertura de `webhooks` (14 %), y las dos decisiones de
+taxonomía que bloquean el umbral de `categoria` — agregar la categoría `gas` y
+definir si se etiqueta por síntoma o por causa raíz.
 
 ---
 

--- a/docs/05-plan-desarrollo-claude-code.md
+++ b/docs/05-plan-desarrollo-claude-code.md
@@ -125,19 +125,36 @@
 
 Verificado ejecutando, no leyendo. Lo que sigue vale más que las tildes de las tablas de arriba.
 
+Actualizado el 2026-08-18, después de probar la lógica completa en runtime (PR #39).
+
 | Fase | Estado | Qué falta concretamente |
 |---|---|---|
 | 0 — Fundaciones | ✅ | Branch protection en `main` (tarea 0.3) nunca se configuró |
 | 1 — Dominio, RBAC, tickets | ✅ | Nada de alcance vigente. RF-D03/D04/D07 superados por ADR-002 |
-| 2 — WhatsApp texto | 🟡 | Falta el paso de resumen+confirmación (RF-B06), la ventana de 24 h y las plantillas HSM versionadas (RF-G02). Las notificaciones salen fire-and-forget, sin cola |
-| 3 — IA real | 🟡 | **Solo falta poner la API key.** Dataset de 302 casos, `ai:eval` con umbrales y persistencia de sugerencias listos. Quedan el panel de baja confianza (3.7) y la telemetría de costo (3.8) |
-| 4 — App móvil | 🟡 | Push notifications (`expo-notifications` no está ni en dependencias) y E2E Maestro. La app tampoco muestra `costosConfirmados` |
+| 2 — WhatsApp texto | ✅ | RF-B06 (resumen + confirmación) cerrado. Notificaciones con cola durable, backoff y reaper; la ventana de 24 h se calcula con `residente.ultimo_inbound_at` |
+| 3 — IA real | 🟡 | **Solo falta poner la API key.** Dataset de 302 casos, `ai:eval` con umbrales y persistencia de sugerencias listos. La telemetría de costo (3.8) ya se muestra en Resumen y en el detalle del ticket. Queda una bandeja dedicada de baja confianza (3.7): hoy la confianza real se ve por ticket, pero no hay cola de revisión filtrada |
+| 4 — App móvil | 🟡 | Push notifications (`expo-notifications` no está ni en dependencias) y E2E Maestro. `costosConfirmados` ya se muestra en el feed y en el detalle |
 | 5 — Conductas y costos | ✅ | Nada. RF-F01 cerrado con la opción A |
 | 6 — Hardening | ❌ | Sin arrancar, salvo el gate de cobertura y el upgrade de drizzle que ya se hicieron |
 
 **Canales de bot:** además de WhatsApp hay Telegram, los dos detrás de `IMessagingProvider`. Telegram no necesita verificación de Meta Business ni plantillas aprobadas, así que conviene para desarrollar.
 
-**Lo que más conviene atacar ahora**, en orden: la key de IA y su corrida de `ai:eval` (desbloquea el capítulo de validación), la cobertura de `bot` (10 %) y `webhooks` (16 %), y la cola de notificaciones.
+**Deuda abierta que rompe una regla no negociable:** `sesion_bot` tiene `tenant_id`
+y `consorcio_ctx_id` pero **no tiene RLS activado ni política** (verificado con
+`pg_class.relrowsecurity`), contra la regla 1 de CLAUDE.md. Su `estado_flujo`
+guarda el texto pendiente del reporte y las opciones de consorcio, así que es dato
+de tenant. `webhook_event` tampoco tiene RLS, pero ahí es correcto: guarda el
+payload crudo del proveedor *antes* de saber a qué tenant corresponde. Falta la
+política de `sesion_bot` y su test en `test:isolation`.
+
+**Cobertura medida el 2026-08-18** (integración, por módulo): global 72,5 %.
+`webhooks` 14 % es el más bajo con diferencia — la firma HMAC y el parseo de
+payloads casi no se ejercitan por HTTP. Después `notifications` 62 % y
+`core-admin` 63 %. `bot` subió de 10 % a 66,6 % con la suite `bot-flujo`.
+
+**Lo que más conviene atacar ahora**, en orden: la key de IA y su corrida de
+`ai:eval` (desbloquea el capítulo de validación), la política RLS de `sesion_bot`,
+y la cobertura de `webhooks`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "ai:eval": "turbo run ai:eval --filter=@consorciofix/ai",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
     "clean": "turbo run clean && rm -rf node_modules",
-    "test:coverage": "turbo run test:coverage"
+    "test:coverage": "turbo run test:coverage",
+    "demo": "pnpm --filter @consorciofix/api demo"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\"",
     "clean": "turbo run clean && rm -rf node_modules",
     "test:coverage": "turbo run test:coverage",
-    "demo": "pnpm --filter @consorciofix/api demo"
+    "demo": "pnpm --filter @consorciofix/api demo",
+    "bot": "pnpm --filter @consorciofix/api bot"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/ai/src/eval/dataset.ts
+++ b/packages/ai/src/eval/dataset.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { z } from 'zod';
-import { Categoria, TipoTicket } from '../schemas.js';
+import { Categoria, Intencion, TipoTicket } from '../schemas.js';
 import { Origen, Urgencia } from '@consorciofix/contracts';
 
 /**
@@ -19,13 +19,14 @@ export const EvalCase = z.object({
   text: z.string().min(1),
   expected: z
     .object({
+      intencion: Intencion.optional(),
       tipo: TipoTicket.optional(),
       origen: Origen.optional(),
       categoria: Categoria.optional(),
       urgencia: Urgencia.optional(),
     })
-    .refine((e) => e.tipo || e.origen || e.categoria || e.urgencia, {
-      message: 'expected debe fijar al menos una de tipo/origen/categoria/urgencia',
+    .refine((e) => e.intencion || e.tipo || e.origen || e.categoria || e.urgencia, {
+      message: 'expected debe fijar al menos una de intencion/tipo/origen/categoria/urgencia',
     }),
   /** `synthetic` = escrito a mano; `piloto` = caso real anonimizado (G16). */
   source: z.enum(['synthetic', 'piloto']).default('synthetic'),

--- a/packages/ai/src/eval/datasets/classifier-v1.jsonl
+++ b/packages/ai/src/eval/datasets/classifier-v1.jsonl
@@ -185,7 +185,7 @@
 {"id": "amb004", "text": "Está todo sucio", "expected": {"categoria": "limpieza", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic", "tags": ["ambiguo"]}
 {"id": "amb005", "text": "El vecino hace ruido", "expected": {"categoria": "conducta", "origen": "UNIDAD", "tipo": "CONDUCTA"}, "source": "synthetic", "tags": ["ambiguo"]}
 {"id": "amb006", "text": "Se rompió el ascensor", "expected": {"categoria": "ascensor", "origen": "ESPACIO_COMUN", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic", "tags": ["ambiguo"]}
-{"id": "amb007", "text": "hola", "expected": {"categoria": "otros", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic", "tags": ["ambiguo", "sin-contenido"]}
+{"id": "amb007", "text": "hola", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["sin-contenido", "no-reporte"]}
 {"id": "amb008", "text": "necesito ayuda con un tema del departamento", "expected": {"categoria": "otros", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic", "tags": ["ambiguo", "sin-contenido"]}
 {"id": "mul001", "text": "Se cortó la luz del palier y además el ascensor quedó parado", "expected": {"origen": "ESPACIO_COMUN", "urgencia": "ALTA"}, "source": "synthetic", "tags": ["multi-problema"]}
 {"id": "mul002", "text": "Hay una pérdida de agua que está mojando el tablero eléctrico del pasillo", "expected": {"origen": "ESPACIO_COMUN", "urgencia": "CRITICA"}, "source": "synthetic", "tags": ["multi-problema"]}
@@ -300,3 +300,23 @@
 {"id": "uni053", "text": "El piso del balcón está flojo, se siente que se hunde al pisar", "expected": {"origen": "UNIDAD", "categoria": "seguridad", "urgencia": "CRITICA", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic"}
 {"id": "uni054", "text": "Se cortó la conexión de internet del edificio a mi unidad", "expected": {"origen": "UNIDAD", "categoria": "otros", "urgencia": "MEDIA", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic"}
 {"id": "uni055", "text": "Quiero avisar que cambié la cerradura de mi departamento", "expected": {"origen": "UNIDAD", "categoria": "otros", "urgencia": "BAJA", "tipo": "INFRAESTRUCTURA"}, "source": "synthetic"}
+{"id": "int001", "text": "¿cuál fue el último registro?", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int002", "text": "cómo viene lo del tanque?", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int003", "text": "alguna novedad de mis reclamos?", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int004", "text": "tengo algo pendiente todavía?", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int005", "text": "en qué quedó el reclamo del ascensor", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int006", "text": "ya lo arreglaron lo que reporté la semana pasada?", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int007", "text": "che me podés decir el estado de mis tickets", "expected": {"intencion": "CONSULTA_ESTADO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int008", "text": "qué podés hacer?", "expected": {"intencion": "AYUDA"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int009", "text": "cómo se usa esto", "expected": {"intencion": "AYUDA"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int010", "text": "para qué sirve este bot", "expected": {"intencion": "AYUDA"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int011", "text": "gracias!", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int012", "text": "buenas tardes, todo bien?", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int013", "text": "no te dije gracias", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int014", "text": "dale, listo", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int015", "text": "feliz año para toda la administración", "expected": {"intencion": "OTRO"}, "source": "synthetic", "tags": ["intencion", "no-reporte"]}
+{"id": "int016", "text": "se rompió el ascensor, alguna novedad?", "expected": {"intencion": "REPORTE"}, "source": "synthetic", "tags": ["intencion", "trampa-parece-pregunta"]}
+{"id": "int017", "text": "hola, sigue sin luz el palier, ya lo vieron?", "expected": {"intencion": "REPORTE"}, "source": "synthetic", "tags": ["intencion", "trampa-parece-pregunta"]}
+{"id": "int018", "text": "consulta: hay olor a gas en el pasillo, es normal?", "expected": {"intencion": "REPORTE"}, "source": "synthetic", "tags": ["intencion", "trampa-parece-pregunta"]}
+{"id": "int019", "text": "buenas! sabés si van a arreglar la filtración del techo del garage?", "expected": {"intencion": "REPORTE"}, "source": "synthetic", "tags": ["intencion", "trampa-parece-pregunta"]}
+{"id": "int020", "text": "perdón la molestia, se cayó la baranda de la escalera", "expected": {"intencion": "REPORTE"}, "source": "synthetic", "tags": ["intencion", "trampa-parece-pregunta"]}

--- a/packages/ai/src/eval/run.ts
+++ b/packages/ai/src/eval/run.ts
@@ -147,6 +147,46 @@ async function main(): Promise<void> {
     console.log('');
   }
 
+  // ── RF-C03: urgencia técnica, independiente del tono ─────────────────────
+  //
+  // El dataset tiene 20 casos trampa etiquetados `tono-inflado` y
+  // `tono-atenuado`: "URGENTÍSIMO!!! SE QUEMÓ UNA LAMPARITA" tiene que dar BAJA,
+  // y "nada importante, pero hay un cable pelado" tiene que dar CRITICA. Son la
+  // única evidencia de que el clasificador juzga por criterio técnico y no por
+  // cuánto grita quien escribe — que es el argumento central de la tesis y lo que
+  // distingue esto de un triage humano leyendo por tono.
+  //
+  // Estaban en el dataset desde el principio y el eval los promediaba con el
+  // resto, así que la métrica que sostiene el argumento no se reportaba nunca.
+  const conTono = casos
+    .map((caso, i) => ({ caso, salida: salidas[i] }))
+    .filter(({ caso }) => caso.tags?.some((t) => t.startsWith('tono-')));
+
+  if (conTono.length > 0) {
+    const porTag = new Map<string, { total: number; aciertos: number }>();
+    const desaciertos: string[] = [];
+    for (const { caso, salida } of conTono) {
+      const esperado = caso.expected.urgencia;
+      if (!esperado) continue;
+      const tag = caso.tags?.find((t) => t.startsWith('tono-')) ?? 'tono';
+      const acc = porTag.get(tag) ?? { total: 0, aciertos: 0 };
+      acc.total += 1;
+      if (salida?.urgencia === esperado) acc.aciertos += 1;
+      else desaciertos.push(`      ${caso.id}: esperaba ${esperado}, dio ${salida?.urgencia ?? '(nada)'} — "${caso.text.slice(0, 64)}"`);
+      porTag.set(tag, acc);
+    }
+    const total = [...porTag.values()].reduce((a, x) => a + x.total, 0);
+    const aciertos = [...porTag.values()].reduce((a, x) => a + x.aciertos, 0);
+    console.log('  ── RF-C03: urgencia frente al tono ──');
+    console.log(`    global: ${pct(aciertos / total)} (${aciertos}/${total})`);
+    for (const [tag, x] of [...porTag].sort()) {
+      const que = tag === 'tono-inflado' ? 'dramatizado, urgencia real baja' : 'minimizado, urgencia real alta';
+      console.log(`    ${tag.padEnd(15)} ${pct(x.aciertos / x.total)} (${x.aciertos}/${x.total})  ${que}`);
+    }
+    for (const d of desaciertos.slice(0, 8)) console.log(d);
+    console.log('');
+  }
+
   // Umbrales
   let ok = true;
   console.log('  ── Criterios de salida ──');

--- a/packages/ai/src/eval/run.ts
+++ b/packages/ai/src/eval/run.ts
@@ -28,6 +28,11 @@ import { computeTaskMetrics, pct, renderTask, type Par, type TaskMetrics } from 
 const UMBRALES: Record<string, number> = {
   // El tipo decide el circuito entero (anonimato, votos, a quién se acusa), así
   // que equivocarlo es más caro que equivocar una categoría: se le exige más.
+  // La intención decide si se crea un ticket o no. Errarle hacia REPORTE mete
+  // basura inventada en la bandeja de la administración —el bug que originó este
+  // campo— y errarle en la otra dirección pierde un reclamo. Se le exige lo mismo
+  // que al tipo por la misma razón: condiciona todo lo que viene después.
+  intencion: 0.95,
   tipo: 0.95,
   origen: 0.85,
   categoria: 0.9,
@@ -115,7 +120,13 @@ async function main(): Promise<void> {
   });
   const elapsedMs = Date.now() - t0;
 
-  const tareas: Array<'tipo' | 'origen' | 'categoria' | 'urgencia'> = ['tipo', 'origen', 'categoria', 'urgencia'];
+  const tareas: Array<'intencion' | 'tipo' | 'origen' | 'categoria' | 'urgencia'> = [
+    'intencion',
+    'tipo',
+    'origen',
+    'categoria',
+    'urgencia',
+  ];
   const metricas: TaskMetrics[] = [];
   const fallos: Fallo[] = [];
 

--- a/packages/ai/src/factory.ts
+++ b/packages/ai/src/factory.ts
@@ -69,8 +69,9 @@ export function createEmbedder(): IEmbedder {
       return new MockEmbedder();
     }
     case 'mock':
-    default:
       return new MockEmbedder();
+    default:
+      return warnProveedorNoSoportado('embedder', provider, ['openai', 'mock'], new MockEmbedder());
   }
 }
 
@@ -83,8 +84,9 @@ export function createTranscriber(): ITranscriber {
       return new OpenAITranscriber(key);
     }
     case 'mock':
-    default:
       return new MockTranscriber();
+    default:
+      return warnProveedorNoSoportado('transcriber', provider, ['openai', 'mock'], new MockTranscriber());
   }
 }
 
@@ -110,5 +112,29 @@ export function createVision(): IImageVision {
 function warnFallback<T>(missingEnv: string, fallback: T): T {
   // eslint-disable-next-line no-console
   console.warn(`[ai] ${missingEnv} missing — falling back to mock`);
+  return fallback;
+}
+
+/**
+ * Avisa cuando el proveedor configurado NO existe para esta pieza del pipeline.
+ *
+ * Es el caso de `AI_PROVIDER=anthropic`: Anthropic no tiene API de embeddings ni
+ * de transcripción, así que el embedder y el transcriber caían al `default` y
+ * devolvían el mock **sin decir nada**. Se veía el clasificador contestando de
+ * verdad y era razonable concluir que todo el pipeline era real, mientras el
+ * dedup comparaba vectores falsos y los audios traían texto inventado. Para una
+ * tesis eso es peor que un error: es una medición que parece válida.
+ */
+function warnProveedorNoSoportado<T>(
+  pieza: string,
+  provider: string,
+  soportados: readonly string[],
+  fallback: T,
+): T {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[ai] ${pieza}: el proveedor "${provider}" no está soportado (solo ${soportados.join(', ')}) — ` +
+      `usando mock. Configurá AI_${pieza.toUpperCase()}_PROVIDER aparte si querés uno real.`,
+  );
   return fallback;
 }

--- a/packages/ai/src/mock-classifier.ts
+++ b/packages/ai/src/mock-classifier.ts
@@ -9,6 +9,31 @@ import { ClassifierOutput } from './schemas.js';
 export class MockClassifier implements IClassifier {
   async classify(text: string, opts: { promptVersion: string }) {
     const lower = text.toLowerCase();
+
+    // El modelo real puede negarse a clasificar cuando el mensaje no describe
+    // ningún problema (`es_reporte: false`). El mock imita eso, si no el camino
+    // de abstención del bot no se podría testear sin gastar una llamada paga.
+    // Solo matchea texto enteramente social: cualquier mensaje del dataset de
+    // evaluación tiene contenido además del saludo, así que la baseline no se
+    // mueve.
+    const soloSocial =
+      /^[\s\p{P}]*(?:(?:hola|buenas|buen\s+d[íi]a|buenas\s+(?:tardes|noches)|gracias|no\s+te\s+dije\s+gracias|chau|saludos|todo\s+bien|c[óo]mo\s+(?:va|and[áa]s|est[áa]s))[\s\p{P}]*)+$/iu.test(
+        lower.trim(),
+      );
+    if (soloSocial) {
+      return ClassifierOutput.parse({
+        es_reporte: false,
+        titulo: 'Sin reporte',
+        descripcion_normalizada: text.trim() || '(vacío)',
+        tipo: 'INFRAESTRUCTURA',
+        categoria: 'otros',
+        origen: 'UNIDAD',
+        urgencia: 'BAJA',
+        confianza: 0.9,
+        modelo: 'mock-classifier@0.0.1',
+        prompt_version: opts.promptVersion,
+      });
+    }
     const urgencia =
       /fuego|gas|incendio|inundaci/.test(lower)
         ? 'CRITICA'

--- a/packages/ai/src/mock-classifier.ts
+++ b/packages/ai/src/mock-classifier.ts
@@ -10,19 +10,30 @@ export class MockClassifier implements IClassifier {
   async classify(text: string, opts: { promptVersion: string }) {
     const lower = text.toLowerCase();
 
-    // El modelo real puede negarse a clasificar cuando el mensaje no describe
-    // ningún problema (`es_reporte: false`). El mock imita eso, si no el camino
-    // de abstención del bot no se podría testear sin gastar una llamada paga.
-    // Solo matchea texto enteramente social: cualquier mensaje del dataset de
-    // evaluación tiene contenido además del saludo, así que la baseline no se
-    // mueve.
+    // El modelo real distingue qué quiere el vecino (`intencion`) y puede no
+    // clasificar nada. El mock imita eso, si no esos caminos del bot no se
+    // podrían testear sin gastar una llamada paga. Los patrones son deliberadamente
+    // angostos —texto enteramente social, o una pregunta explícita por reportes
+    // propios—: todos los casos del dataset de evaluación traen un problema
+    // adentro, así que la baseline no se mueve.
     const soloSocial =
       /^[\s\p{P}]*(?:(?:hola|buenas|buen\s+d[íi]a|buenas\s+(?:tardes|noches)|gracias|no\s+te\s+dije\s+gracias|chau|saludos|todo\s+bien|c[óo]mo\s+(?:va|and[áa]s|est[áa]s))[\s\p{P}]*)+$/iu.test(
         lower.trim(),
       );
-    if (soloSocial) {
+    // Pregunta por reportes propios: pide un verbo/sustantivo de seguimiento y
+    // que NO haya nada roto en la frase, así "se rompió el ascensor, alguna
+    // novedad?" sigue siendo un reporte.
+    const preguntaEstado =
+      /\?|^(?:como|cómo|que|qué|cual|cuál|hay|tengo|ya)\b/i.test(text.trim()) &&
+      /\b(?:reporte|reportes|reclamo|reclamos|registro|registros|ticket|novedad|novedades|pendiente|pendientes|estado)\b/i.test(
+        lower,
+      ) &&
+      !/\b(?:romp|rot[oa]|perd|fuga|filtra|no funciona|no anda|sin luz|sin agua|olor|ruido|sucio|basura)/i.test(lower);
+
+    const intencion = soloSocial ? 'OTRO' : preguntaEstado ? 'CONSULTA_ESTADO' : null;
+    if (intencion) {
       return ClassifierOutput.parse({
-        es_reporte: false,
+        intencion,
         titulo: 'Sin reporte',
         descripcion_normalizada: text.trim() || '(vacío)',
         tipo: 'INFRAESTRUCTURA',

--- a/packages/ai/src/prompts/CHANGELOG.md
+++ b/packages/ai/src/prompts/CHANGELOG.md
@@ -27,6 +27,7 @@ código 1 si no se alcanzan los umbrales, así que se puede poner en CI.
 | classifier-v1.3 | 2026-08-20 | openai gpt-4o-mini | instalaciones generales son ESPACIO_COMUN; escala de urgencia completa (MEDIA vs ALTA) | 98,3 % | 95,6 % | 85,3 % | 59,7 % |
 | classifier-v1.4 | 2026-08-20 | openai gpt-4o-mini | seguridad por principio de riesgo y no por lista de objetos; se saca "portones automáticos ⇒ electricidad", que contradecía al dataset | 98,3 % | 94,9 % | 85,0 % | 62,5 % |
 | classifier-v1.5 | 2026-08-20 | openai gpt-4o-mini | desempate asimétrico (ante riesgo a personas, CRÍTICA) + el tono no altera la urgencia en ninguna dirección | **99,0 %** | **95,6 %** | **88,3 %** | **63,5 %** |
+| classifier-v1.6 | 2026-08-20 | openai gpt-4o-mini | `es_reporte`: el modelo puede abstenerse cuando el mensaje no describe ningún problema | **99,0 %** | **97,0 %** | 87,3 % | **65,5 %** |
 
 ### RF-C03 — urgencia frente al tono (20 casos trampa)
 
@@ -34,6 +35,7 @@ código 1 si no se alcanzan los umbrales, así que se puede poner en CI.
 |---|---|---|---|
 | classifier-v1.4 | 60,0 % | 80,0 % | 40,0 % |
 | classifier-v1.5 | **70,0 %** | 60,0 % | **80,0 %** |
+| classifier-v1.6 | **70,0 %** | **70,0 %** | 70,0 % |
 
 Estos 20 casos son el argumento central de la tesis y **el eval no los medía por
 separado**: estaban en el dataset desde el principio, promediados con los otros
@@ -180,3 +182,34 @@ decirlo así en la defensa.
   origen es genuinamente indeterminable sin repreguntar.
 - **Registros informales, formales y con errores de tipeo**: el canal es
   WhatsApp, no un formulario.
+
+## v1.6 — la abstención (2026-08-20)
+
+Un vecino escribió "Gracias" por Telegram y el bot le abrió un ticket: *"Agujero
+en el techo del pasillo"*, urgencia alta, nada de eso mencionado en el mensaje.
+"No te dije gracias!" salió como un ticket de CONDUCTA titulado *"Agradecimiento
+no expresado"*.
+
+No era un problema de calidad del prompt sino de contrato: el esquema **obligaba
+a clasificar**. Frente a un texto sin ningún problema adentro, la única salida
+válida era inventar uno, y el modelo hacía lo que se le pedía. La respuesta es un
+campo nuevo, `es_reporte`, que le da al modelo una salida honesta, y el bot la
+respeta cortando antes de crear el ticket.
+
+Sobre los 302 casos del dataset no hay regresión: `origen` +1,4 pts y `urgencia`
++2,0 pts, `categoria` −1,0 pt (3 casos sobre 300, dentro del ruido de muestreo de
+un set de este tamaño) y `tipo` igual. Era lo esperable: todos los casos del
+dataset **son** reportes, así que el campo nuevo no cambia nada ahí — el valor
+está justamente en los mensajes que el dataset no tiene.
+
+Eso es también su limitación como medición: la abstención no está evaluada por el
+eval, porque el dataset no incluye ni un solo mensaje que no sea un reporte.
+Quedó verificada a mano contra el modelo real (se abstiene en "Gracias", "No te
+dije gracias!" y "hola todo bien?"; sigue registrando "se rompió el portón" y
+"buenas, hay olor a gas") y con tests de integración contra el mock. Medirla en
+serio pide una clase nueva de casos en el dataset — cortesías, preguntas,
+consultas administrativas— que es trabajo pendiente, no resuelto.
+
+`categoria` sigue abajo del 90 % de corte por lo ya anotado más arriba: falta la
+categoría `gas` y el dataset etiqueta a veces por síntoma y a veces por causa
+raíz. Es deuda de taxonomía, no de prompt.

--- a/packages/ai/src/prompts/CHANGELOG.md
+++ b/packages/ai/src/prompts/CHANGELOG.md
@@ -22,6 +22,65 @@ código 1 si no se alcanzan los umbrales, así que se puede poner en CI.
 |---|---|---|---|---|---|---|---|
 | classifier-v1.0 | 2026-08-17 | mock | baseline del clasificador simulado | — | 61,1 % | 50,7 % | 37,2 % |
 | classifier-v1.1 | 2026-08-17 | mock | detección de `tipo` y `unidad_reportada_texto` (RF-F01) | 88,3 % | 61,1 % | 50,7 % | 37,2 % |
+| classifier-v1.1 | 2026-08-20 | **openai** gpt-4o-mini | primera corrida con el modelo real | 98,7 % | 90,5 % | 80,7 % | 55,6 % |
+| classifier-v1.2 | 2026-08-20 | **openai** gpt-4o-mini | guía por categoría + `otros` como último recurso; conducta ⇒ origen UNIDAD; CRÍTICA vs ALTA definidas | 98,7 % | **94,9 %** | 84,3 % | 56,0 % |
+| classifier-v1.3 | 2026-08-20 | openai gpt-4o-mini | instalaciones generales son ESPACIO_COMUN; escala de urgencia completa (MEDIA vs ALTA) | 98,3 % | 95,6 % | 85,3 % | 59,7 % |
+| classifier-v1.4 | 2026-08-20 | openai gpt-4o-mini | seguridad por principio de riesgo y no por lista de objetos; se saca "portones automáticos ⇒ electricidad", que contradecía al dataset | 98,3 % | 94,9 % | 85,0 % | 62,5 % |
+| classifier-v1.5 | 2026-08-20 | openai gpt-4o-mini | desempate asimétrico (ante riesgo a personas, CRÍTICA) + el tono no altera la urgencia en ninguna dirección | **99,0 %** | **95,6 %** | **88,3 %** | **63,5 %** |
+
+### RF-C03 — urgencia frente al tono (20 casos trampa)
+
+| Version | global | tono-inflado | tono-atenuado |
+|---|---|---|---|
+| classifier-v1.4 | 60,0 % | 80,0 % | 40,0 % |
+| classifier-v1.5 | **70,0 %** | 60,0 % | **80,0 %** |
+
+Estos 20 casos son el argumento central de la tesis y **el eval no los medía por
+separado**: estaban en el dataset desde el principio, promediados con los otros
+282. Se agregó la métrica al `ai:eval`, partida en las dos direcciones del sesgo,
+porque fallar en cada una significa algo distinto: en `tono-inflado` el sistema se
+deja llevar por el drama; en `tono-atenuado` pasa por alto un peligro real porque
+el vecino fue educado, y eso es mucho más grave.
+
+**El hallazgo no es el porcentaje, es el patrón.** En v1.4 el modelo detectaba
+correctamente la gravedad de los casos minimizados —los ubicaba en ALTA, no en
+BAJA— pero descontaba un nivel por la cortesía del mensaje. En la dirección
+opuesta pasaba lo simétrico: *"URGENTÍSIMO una lamparita"* subía de BAJA a MEDIA.
+El tono corría la urgencia exactamente un nivel, en su misma dirección.
+
+v1.5 lo corrige con un desempate **asimétrico**: sin riesgo a personas se elige el
+nivel menor (inflar todo hace que nada sea urgente), pero ante riesgo se elige
+CRÍTICA aunque haya duda, porque subestimar un peligro cuesta una persona
+lastimada y sobreestimarlo cuesta una visita de más. El acierto en `tono-atenuado`
+pasó de 40 % a 80 %, a costa de `tono-inflado` (80 % → 60 %). Es el intercambio
+correcto y conviene defenderlo como decisión, no disimularlo como mejora neta.
+
+### Nota metodológica: por qué se paró en v1.5
+
+Categoría recorrió 80,7 % → 84,3 % → 85,3 % → 85,0 % → 88,3 % en cinco
+iteraciones, contra un umbral de 90 % (RF-C02). Seguir agregando reglas para que
+el modelo acierte casos puntuales de este dataset sería **sobreajustar al conjunto
+de evaluación**: el número sube y la capacidad real no. Los cambios de v1.3 a v1.5
+se limitaron a corregir contradicciones introducidas por versiones anteriores y a
+reemplazar listas de objetos por los principios que esas listas intentaban
+expresar.
+
+El análisis de los 47 desaciertos de categoría en v1.3 mostró tres grupos:
+
+1. **Una contradicción propia**: v1.2 mandaba "portones automáticos" a
+   electricidad y el dataset los etiqueta `otros`. Corregido en v1.4.
+2. **Una categoría faltante en la taxonomía**: el gas no es plomería ni
+   electricidad, y aparece en al menos cuatro casos. El dataset los pone en
+   `plomeria` (por los caños) y el modelo en `otros` o `seguridad` (por el
+   riesgo); los dos criterios son razonables. RF-C02 ya prevé que la taxonomía sea
+   configurable, así que agregar `gas` es coherente con el diseño.
+3. **Ambigüedad irreducible entre síntoma y causa raíz**: *"se cayó un pedazo de
+   revoque del techo del baño por la humedad"* está etiquetado `plomeria` (la
+   causa) y el modelo responde `otros` (lo que se ve). Hace falta fijar el
+   criterio y aplicarlo a los 302 casos antes de que este número signifique algo.
+
+Antes de volver a tocar el prompt conviene resolver 2 y 3, que son decisiones de
+producto y de etiquetado, no de ingeniería de prompts.
 
 ### Por qué `tipo` tiene el umbral más alto (95 %)
 
@@ -52,6 +111,59 @@ pnpm ai:eval -- --provider openai --out results/classifier-v1.0-openai.json
 
 Esa corrida es la que produce las métricas del capítulo de validación de la
 tesis. El comando imprime al final una fila lista para pegar en esta tabla.
+
+## Lectura de la corrida del 2026-08-20 (primera con modelo real)
+
+Antes de esta fecha las cifras salían del mock, que no es una medición: el stub
+clasifica por palabras clave y siempre acierta lo que él mismo decidió. Al poner
+una API key apareció que **el clasificador real nunca había funcionado**: el modo
+estricto de salida estructurada de OpenAI exige que todas las propiedades estén en
+`required`, dos campos eran `optional()`, y las 302 llamadas se rechazaban. Está
+en el commit que arregla el schema; vale para la tesis como ejemplo de que
+"implementado" y "funciona" no son lo mismo.
+
+**Qué cambió v1.2 y por qué.** La matriz de confusión de v1.1 mostraba una sola
+causa dominante en categoría: `otros` con 50,5 % de precisión, comiéndose 15 casos
+de plomería, 15 de seguridad, 11 de conducta y 7 de limpieza. Cuando el modelo
+elegía una categoría específica acertaba entre 96 % y 100 %, así que el problema
+no era de capacidad sino de instrucción: el prompt listaba las siete categorías
+sin decir qué entra en cada una ni que `otros` fuera el último recurso.
+
+**El eval encontró una ambigüedad de la especificación, no solo errores.** Los 21
+desaciertos de `origen` en v1.1 eran casi todos conductas donde el dataset dice
+UNIDAD y el modelo decía ESPACIO_COMUN (*"el del 3D no levanta la caca del perro
+en el jardín"*). Ninguno se equivocaba: `origen` significaba dos cosas distintas
+—dónde ocurre el hecho, o quién puede verlo—. v1.2 lo define como decisión de
+visibilidad y fija que una conducta es siempre UNIDAD, porque publicar una
+denuncia a todo el consorcio expone a las dos partes. El recall de UNIDAD pasó de
+84,3 % a 97,0 %.
+
+**Lo que sigue faltando, con su causa identificada.**
+
+- **Categoría 84,3 % contra un umbral de 90 %** (RF-C02). `otros` mejoró de 50,5 %
+  a 60,7 % de precisión pero sigue absorbiendo 12 casos de plomería y 10 de
+  seguridad. Seguridad tiene 64,7 % de recall.
+- **Origen: instalaciones generales mal clasificadas.** El prompt enumera lugares
+  comunes (palier, hall, cochera) y no menciona instalaciones centrales, así que
+  *"la calefacción central"*, *"el filtro del tanque"*, *"el matafuegos del quinto
+  piso"* y *"el toldo de la terraza"* se van a UNIDAD. Es una omisión del prompt,
+  no del modelo.
+- **Urgencia 56 %, y es el más débil por una razón de especificación**: de 105
+  casos MEDIA el modelo dijo ALTA en 49. v1.2 definió CRÍTICA vs ALTA (recall de
+  CRÍTICA: 32 % → 42 %) pero **nadie definió dónde termina MEDIA y empieza ALTA**,
+  ni en el prompt ni en los requerimientos. Sin esa definición la métrica mide un
+  desacuerdo, no un error.
+- **Ambigüedades del dataset que ningún prompt puede resolver.** *"Entraron a
+  robar a una cochera y forzaron un auto"* no es una cosa rota ni la conducta de un
+  vecino: la taxonomía no tiene dónde ponerlo. *"Dejan la basura afuera del
+  contenedor"* es conducta y limpieza a la vez. *"El caño de la cocina del 4to
+  gotea sobre la cochera"* nace en una unidad y afecta un espacio común. Antes de
+  seguir subiendo números hay que decidir qué es la respuesta correcta en estos
+  casos, o marcarlos como indeterminables igual que ya se hace con los `ambiguo`.
+
+El dataset es 100 % sintético (302 casos, 0 del piloto). Las cifras miden
+consistencia contra etiquetas propias, no desempeño en producción, y conviene
+decirlo así en la defensa.
 
 ## Notas de diseño del dataset
 

--- a/packages/ai/src/prompts/CHANGELOG.md
+++ b/packages/ai/src/prompts/CHANGELOG.md
@@ -28,6 +28,9 @@ código 1 si no se alcanzan los umbrales, así que se puede poner en CI.
 | classifier-v1.4 | 2026-08-20 | openai gpt-4o-mini | seguridad por principio de riesgo y no por lista de objetos; se saca "portones automáticos ⇒ electricidad", que contradecía al dataset | 98,3 % | 94,9 % | 85,0 % | 62,5 % |
 | classifier-v1.5 | 2026-08-20 | openai gpt-4o-mini | desempate asimétrico (ante riesgo a personas, CRÍTICA) + el tono no altera la urgencia en ninguna dirección | **99,0 %** | **95,6 %** | **88,3 %** | **63,5 %** |
 | classifier-v1.6 | 2026-08-20 | openai gpt-4o-mini | `es_reporte`: el modelo puede abstenerse cuando el mensaje no describe ningún problema | **99,0 %** | **97,0 %** | 87,3 % | **65,5 %** |
+| classifier-v1.7 | 2026-08-20 | openai gpt-4o-mini | `intencion` reemplaza a `es_reporte`: el modelo dice *qué* quiere el vecino, no solo que "no es un reporte" | 98,7 % | 96,3 % | 86,0 % | 57,7 % |
+| classifier-v1.8 | 2026-08-20 | openai gpt-4o-mini | regla asimétrica: si menciona un problema es REPORTE aunque esté redactado como pregunta | 99,0 % | 95,3 % | 86,3 % | 59,4 % |
+| classifier-v1.9 | 2026-08-20 | openai gpt-4o-mini | misma regla, bloque comprimido a 7 líneas | **98,7 %** | **96,3 %** | **87,6 %** | 59,0 % |
 
 ### RF-C03 — urgencia frente al tono (20 casos trampa)
 
@@ -213,3 +216,96 @@ consultas administrativas— que es trabajo pendiente, no resuelto.
 `categoria` sigue abajo del 90 % de corte por lo ya anotado más arriba: falta la
 categoría `gas` y el dataset etiqueta a veces por síntoma y a veces por causa
 raíz. Es deuda de taxonomía, no de prompt.
+
+## v1.7 → v1.9 — la intención, y por qué hicieron falta cuatro variantes (2026-08-20)
+
+`es_reporte` sabía decir "esto no es un reporte" pero no *qué* era. Un vecino
+preguntó "¿cuál fue el último registro?" y recibió "no encontré un problema para
+registrar": cierto e inútil. `intencion` lo reemplaza —un solo campo, no un
+booleano más un enum, porque dos campos que contestan la misma pregunta se
+desincronizan— con cuatro valores: REPORTE, CONSULTA_ESTADO, AYUDA, OTRO. El bot
+rutea CONSULTA_ESTADO y AYUDA al mismo handler que atiende la palabra escrita
+exacta, así que la lista de reportes se arma en un solo lugar.
+
+### El error que importa no es simétrico
+
+v1.7 midió 81 % de intención y los 4 fallos fueron **todos en la misma
+dirección**: problemas reales redactados como pregunta ruteados a
+CONSULTA_ESTADO. Entre ellos "hay olor a gas en el pasillo, ¿es normal?". Ese es
+el error caro: un reclamo que nunca entra al sistema. El inverso —abrir el
+borrador de un ticket para una pregunta— lo cancela el vecino con un "no".
+
+v1.8 agregó la regla explícita con su razón: *si menciona un problema es REPORTE,
+aunque esté escrito como pregunta y aunque pregunte por algo ya reportado; si
+resulta repetido el dedup lo detecta y lo suma al existente, pero lo que no se
+registra no existe.* Eso lo llevó a 100 %.
+
+### Cuatro variantes, y la posición del bloque importa
+
+| variante | intención | tipo | origen | categoría | urgencia |
+|---|---|---|---|---|---|
+| v1.7 — 17 líneas, arriba | 81,0 % | 98,7 % | 96,3 % | 86,0 % | 57,7 % |
+| v1.8a — 11 líneas, arriba | 100,0 % | 98,0 % | 93,9 % | 87,0 % | 57,3 % |
+| v1.8b — 11 líneas, al final | 95,2 % | 99,0 % | 95,3 % | 86,3 % | 59,4 % |
+| **v1.9 — 7 líneas, arriba** | **100,0 %** | **98,7 %** | **96,3 %** | **87,6 %** | 59,0 % |
+
+Un bloque largo al principio del prompt empuja la escala de urgencia hacia abajo y
+la degrada; moverlo al final recupera tipo y origen pero pierde un caso de
+intención. Comprimirlo a 7 líneas y dejarlo arriba gana en las cuatro columnas a
+la vez. La lección es transferible: en este prompt, **cuánto ocupa una instrucción
+compite con las que vienen después**, así que agregar una tarea no es gratis
+aunque el texto agregado sea correcto.
+
+### Lo que este ejercicio destapó sobre la medición
+
+La urgencia parecía haber caído 8 puntos (65,5 % → 57,7 %). Antes de escribirlo
+como costo de la feature se corrió un **control**: el texto del prompt de v1.6
+contra el dataset actual. Dio 61,1 %, no 65,5 %. Con prompt idéntico.
+
+Entonces se corrió v1.9 **tres veces sin cambiar nada**:
+
+| corrida | intención | tipo | origen | categoría | urgencia |
+|---|---|---|---|---|---|
+| a | 100,0 % | 98,7 % | 96,3 % | 87,6 % | 59,0 % |
+| b | 100,0 % | 98,7 % | 95,6 % | 87,6 % | 61,8 % |
+| c | 100,0 % | 98,7 % | 95,9 % | 88,0 % | 59,0 % |
+| rango | 0,0 | 0,0 | 0,7 | 0,4 | **2,8** |
+
+Con `temperature: 0` la urgencia se mueve ~3 puntos entre corridas idénticas; las
+otras cuatro tareas se mueven menos de 1 punto. La urgencia es la única con cuatro
+clases ordinales y fronteras discutibles (MEDIA vs ALTA), así que es la más
+sensible al no-determinismo del proveedor —que existe a temperatura 0: batching y
+ruteo del modelo no garantizan reproducibilidad—.
+
+**Consecuencia para leer la tabla de arriba:** las diferencias de urgencia de ~3
+puntos entre versiones no son evidencia de nada. Varias de las "mejoras" que este
+changelog venía narrando (56,0 → 59,7 → 62,5 → 63,5) caen dentro de esa banda y
+no deberían leerse como efecto del prompt. Entre v1.6 y v1.9 la urgencia mide
+61,1 % (una corrida) contra 59,9 % ± 1,6 (tres corridas): indistinguible. El
+65,5 % registrado antes queda arriba de esa banda, así que no se puede descartar
+un costo real chico, pero tampoco establecerlo con una corrida por configuración.
+
+Cómo medir de acá en adelante: **tres corridas y reportar rango** para cualquier
+afirmación sobre urgencia. Para tipo, origen, categoría e intención una corrida
+alcanza.
+
+### La abstención ahora se mide
+
+El dataset tenía 302 casos y todos eran reportes, así que la abstención no se
+podía medir —era la limitación anotada en v1.6—. Se agregaron 20 casos con
+`expected.intencion` (7 CONSULTA_ESTADO, 3 AYUDA, 5 OTRO y **5 trampas**: problemas
+reales redactados como pregunta, que deben salir REPORTE). Las trampas son lo que
+impide aprobar la métrica abstiniéndose siempre.
+
+También se reetiquetó `amb007` ("hola"), que esperaba `categoria: otros` y `tipo:
+INFRAESTRUCTURA`. Esa etiqueta pedía exactamente lo que v1.6 vino a arreglar:
+convertir un saludo en un ticket de infraestructura. Ahora espera
+`intencion: OTRO`.
+
+`intencion` entra a los criterios de salida con el mismo umbral que `tipo` (95 %)
+porque condiciona todo lo que viene después: errarle hacia REPORTE mete basura
+inventada en la bandeja y errarle en la otra dirección pierde un reclamo.
+
+`categoria` sigue abajo del 90 % por lo ya anotado: falta la categoría `gas` y el
+dataset etiqueta a veces por síntoma y a veces por causa raíz. Deuda de taxonomía,
+no de prompt.

--- a/packages/ai/src/prompts/classifier-v1.ts
+++ b/packages/ai/src/prompts/classifier-v1.ts
@@ -3,9 +3,16 @@
  * Versionado: cambios requieren correr `pnpm ai:eval` y registrar en CHANGELOG.md
  * (regla 9 de CLAUDE.md).
  */
-export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.5';
+export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.6';
 
 export const CLASSIFIER_SYSTEM = `Sos un asistente que recibe descripciones de problemas en edificios, barrios cerrados u oficinas de Argentina (español rioplatense) y devuelve una clasificación estructurada.
+
+PRIMERO decidí si hay algo que registrar. Si el mensaje NO describe ningún
+problema —un saludo, un "gracias", un "ok", una pregunta, una charla, o texto sin
+información— devolvé es_reporte: false y completá el resto con lo mínimo. NO
+inventes un problema que el mensaje no menciona: un "gracias" no es un agujero en
+el techo. Si hay aunque sea un indicio de algo que arreglar o de una queja sobre
+un vecino, es_reporte: true.
 
 Categorías permitidas (string): plomeria, electricidad, ascensor, limpieza, seguridad, conducta, otros.
 

--- a/packages/ai/src/prompts/classifier-v1.ts
+++ b/packages/ai/src/prompts/classifier-v1.ts
@@ -3,11 +3,27 @@
  * Versionado: cambios requieren correr `pnpm ai:eval` y registrar en CHANGELOG.md
  * (regla 9 de CLAUDE.md).
  */
-export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.1';
+export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.5';
 
 export const CLASSIFIER_SYSTEM = `Sos un asistente que recibe descripciones de problemas en edificios, barrios cerrados u oficinas de Argentina (español rioplatense) y devuelve una clasificación estructurada.
 
 Categorías permitidas (string): plomeria, electricidad, ascensor, limpieza, seguridad, conducta, otros.
+
+Qué entra en cada categoría:
+- plomeria: agua, desagües, cloacas, humedad, filtraciones, termotanques, bombas de agua, tanques, canillas, inodoros, rejillas.
+- electricidad: luz, tablero, cableado, cortocircuitos, iluminación, portero eléctrico.
+- ascensor: cualquier cosa del ascensor o su sala de máquinas.
+- limpieza: basura, residuos, higiene de espacios comunes, plagas, olores por suciedad.
+- seguridad: cualquier cosa donde alguien pueda lastimarse o entrar sin permiso.
+  El criterio es el riesgo, no el objeto: un escalón roto donde ya se tropezó
+  gente, una baranda floja, algo que puede caerse desde un balcón, un vidrio roto
+  que deja un acceso abierto y una cerradura que no cierra son TODOS seguridad,
+  aunque el objeto sea de albañilería o de carpintería. Incluye también matafuegos,
+  salidas de emergencia, cámaras, rejas e intrusos.
+- conducta: SIEMPRE que el tipo sea CONDUCTA. Si es una queja sobre lo que hace un vecino, la categoría es conducta, sin excepción.
+- otros: SOLO cuando el problema no encaja en ninguna de las anteriores (ej. una puerta de madera hinchada, un vidrio roto, un reclamo administrativo).
+
+Elegí la categoría más específica que aplique. "otros" es el último recurso: antes de usarla, revisá una por una si alguna de las otras seis encaja. Si dudás entre dos específicas, elegí la del sistema que hay que intervenir para resolverlo.
 
 Tipo (decide el circuito de gestión):
 - CONDUCTA: el reporte es una queja sobre el COMPORTAMIENTO de otro vecino (ruidos, mascotas, estacionar en lugar ajeno, basura fuera de horario, malos tratos). Lo que molesta es lo que otra persona hace, no algo roto.
@@ -16,15 +32,65 @@ Regla práctica: si el problema se soluciona arreglando o reemplazando una cosa,
 
 Si el tipo es CONDUCTA y el texto menciona la unidad del vecino señalado (ej. "el del 5B", "la del 3ro A", "lote 12"), copiala TAL CUAL en el campo unidad_reportada_texto. No la inventes ni la normalices: si no la menciona, omitila. Un humano la va a confirmar antes de que tenga efecto.
 
-Origen (decisión de visibilidad):
-- UNIDAD: el problema está dentro o afecta exclusivamente a una unidad (depto, local, lote individual).
-- ESPACIO_COMUN: afecta espacios comunes (palier, hall, pasillo, escalera, cochera, jardín, SUM, pileta, ascensor).
+Origen (decisión de visibilidad, NO de ubicación física):
+- UNIDAD: lo ven solo la administración y los ocupantes de una unidad.
+- ESPACIO_COMUN: lo ven todos los vecinos del consorcio.
+
+Si el tipo es CONDUCTA, el origen es SIEMPRE UNIDAD, incluso cuando el hecho
+ocurre en un espacio común. Una denuncia sobre un vecino se maneja en privado
+entre la administración y la unidad señalada: publicarla a todo el consorcio
+expondría a las dos partes. Que el perro ensucie el jardín no la vuelve pública.
+
+Si el tipo es INFRAESTRUCTURA, preguntate a quién afecta:
+- ESPACIO_COMUN: espacios compartidos (palier, hall, pasillo, escalera, cochera,
+  jardín, SUM, pileta, terraza, azotea, ascensor, fachada, vereda) Y TAMBIÉN toda
+  instalación que sirve a más de una unidad, aunque el reporte no diga dónde está:
+  tanque de agua, bomba, filtro, calefacción o caldera central, medidores
+  colectivos, matafuegos, luces de emergencia, portero eléctrico, antena, toldos
+  del edificio, cañerías troncales.
+- UNIDAD: está dentro de un depto, local o lote y afecta solo a sus ocupantes
+  (canilla del baño, termotanque individual, la puerta de ese depto).
+
+Si algo nace en una unidad pero daña un espacio común o a otra unidad (un caño de
+un depto que gotea sobre la cochera), es ESPACIO_COMUN: la reparación la coordina
+la administración.
 
 Urgencia técnica objetiva (NO mirar tono emocional):
-- CRITICA: riesgo a personas, fuego, gas, electrocución, inundación grave, falla estructural.
-- ALTA: pérdida de servicio esencial (sin luz, sin agua, ascensor parado, plomería con daño progresivo).
-- MEDIA: confort comprometido (calefacción, manijas, iluminación parcial, limpieza puntual).
-- BAJA: estético / no urgente (pintura, ruidos esporádicos, mantenimiento programado).
+- CRITICA: hay riesgo para las personas AHORA, o daño material que crece rápido si
+  nadie interviene hoy. Fuego, olor a gas, cables pelados o agua sobre
+  electricidad, alguien encerrado en el ascensor, inundación con agua acumulada,
+  caño reventado a presión, mampostería o balcón con riesgo de desprendimiento,
+  un intruso dentro del edificio.
+- ALTA: se perdió un servicio esencial pero nadie está en peligro. Sin luz, sin
+  agua, ascensor detenido y vacío, cloaca tapada sin desborde, termotanque sin
+  calentar, portón que no cierra dejando el edificio abierto.
+- MEDIA: molesta el uso diario pero el servicio sigue funcionando, y esperar unos
+  días no empeora nada. Calefacción que calienta poco, una de varias luces
+  quemada, canilla que gotea, ascensor lento o ruidoso pero andando, limpieza
+  puntual pendiente, una cerradura dura.
+- BAJA: estético o mantenimiento programado, no afecta el uso. Pintura descascarada,
+  una mancha, un cartel torcido, ruido esporádico, algo desprolijo.
+
+Al elegir entre MEDIA y ALTA, la pregunta es: ¿el servicio se perdió, o solo
+anda peor? Si anda peor pero anda, es MEDIA. ALTA es cuando dejó de funcionar.
+
+Ante la duda, el desempate NO es simétrico:
+- Si NO hay riesgo para personas, elegí el nivel MENOR. Inflar todo hace que nada
+  sea urgente y la administración deja de poder priorizar.
+- Si HAY riesgo para personas —electricidad expuesta, gas, estructura, algo que
+  puede caerse, una salida de emergencia bloqueada— elegí CRITICA aunque dudes.
+  Subestimar un peligro cuesta una persona lastimada; sobreestimarlo cuesta una
+  visita de más.
+
+El tono del mensaje NO altera la urgencia, en NINGUNA de las dos direcciones:
+- Que alguien escriba "URGENTÍSIMO", en mayúsculas o repita signos de exclamación
+  no sube la urgencia. Una lamparita quemada es BAJA aunque el mensaje grite.
+- Que alguien pida disculpas, diga "sin apuro", "cuando puedan", "consulta menor"
+  o "nada importante" NO baja la urgencia. Un cable pelado es CRITICA aunque lo
+  cuenten pidiendo permiso. La gente educada minimiza los peligros al escribirlos,
+  y ese es exactamente el caso donde el criterio técnico tiene que imponerse.
+
+Clasificá el hecho descrito, no el estado de ánimo de quien lo describe.
 
 Devolvé SOLAMENTE el JSON pedido por el schema. Sin prefacios, sin explicaciones.`;
 

--- a/packages/ai/src/prompts/classifier-v1.ts
+++ b/packages/ai/src/prompts/classifier-v1.ts
@@ -3,16 +3,17 @@
  * Versionado: cambios requieren correr `pnpm ai:eval` y registrar en CHANGELOG.md
  * (regla 9 de CLAUDE.md).
  */
-export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.6';
+export const CLASSIFIER_PROMPT_VERSION = 'classifier-v1.9';
 
 export const CLASSIFIER_SYSTEM = `Sos un asistente que recibe descripciones de problemas en edificios, barrios cerrados u oficinas de Argentina (español rioplatense) y devuelve una clasificación estructurada.
 
-PRIMERO decidí si hay algo que registrar. Si el mensaje NO describe ningún
-problema —un saludo, un "gracias", un "ok", una pregunta, una charla, o texto sin
-información— devolvé es_reporte: false y completá el resto con lo mínimo. NO
-inventes un problema que el mensaje no menciona: un "gracias" no es un agujero en
-el techo. Si hay aunque sea un indicio de algo que arreglar o de una queja sobre
-un vecino, es_reporte: true.
+PRIMERO el campo intencion: si el mensaje menciona algo roto, mal, faltante o
+riesgoso es REPORTE, aunque esté escrito como pregunta ("se rompió el ascensor,
+alguna novedad?" y "¿van a arreglar la filtración?" son REPORTE: perder un
+reclamo es el error más caro). Si NO menciona ningún problema: CONSULTA_ESTADO si
+pregunta por sus reportes, AYUDA si pregunta qué podés hacer, OTRO para saludos,
+gracias y charla — y ahí completá el resto con lo mínimo, sin inventar un problema
+que el mensaje no menciona.
 
 Categorías permitidas (string): plomeria, electricidad, ascensor, limpieza, seguridad, conducta, otros.
 
@@ -101,30 +102,10 @@ Clasificá el hecho descrito, no el estado de ánimo de quien lo describe.
 
 Devolvé SOLAMENTE el JSON pedido por el schema. Sin prefacios, sin explicaciones.`;
 
-export const CLASSIFIER_JSON_SCHEMA = {
-  type: 'object',
-  additionalProperties: false,
-  required: [
-    'titulo',
-    'descripcion_normalizada',
-    'tipo',
-    'categoria',
-    'origen',
-    'urgencia',
-    'confianza',
-  ],
-  properties: {
-    titulo: { type: 'string', minLength: 3, maxLength: 140 },
-    descripcion_normalizada: { type: 'string', minLength: 1, maxLength: 2000 },
-    tipo: { type: 'string', enum: ['INFRAESTRUCTURA', 'CONDUCTA'] },
-    categoria: {
-      type: 'string',
-      enum: ['plomeria', 'electricidad', 'ascensor', 'limpieza', 'seguridad', 'conducta', 'otros'],
-    },
-    unidad_reportada_texto: { type: ['string', 'null'], maxLength: 60 },
-    origen: { type: 'string', enum: ['UNIDAD', 'ESPACIO_COMUN'] },
-    urgencia: { type: 'string', enum: ['CRITICA', 'ALTA', 'MEDIA', 'BAJA'] },
-    ubicacion: { type: ['string', 'null'], maxLength: 200 },
-    confianza: { type: 'number', minimum: 0, maximum: 1 },
-  },
-} as const;
+/*
+ * Acá había un JSON Schema escrito a mano (`CLASSIFIER_JSON_SCHEMA`) que nadie
+ * importaba: `SdkClassifier` deriva el esquema del Zod `ClassifierModelOutput`.
+ * Era una segunda fuente de verdad que se desincronizó en v1.6 y otra vez en
+ * v1.7 —le faltaban los campos nuevos— y que leída de afuera parecía el contrato
+ * real. El contrato es el Zod de `schemas.ts`.
+ */

--- a/packages/ai/src/schemas.ts
+++ b/packages/ai/src/schemas.ts
@@ -37,14 +37,25 @@ export const ClassifierModelOutput = z.object({
   descripcion_normalizada: z.string().min(1).max(2000).describe('El reporte reescrito de forma clara y neutra'),
   tipo: TipoTicket.describe('CONDUCTA si se queja del comportamiento de un vecino; si no, INFRAESTRUCTURA'),
   categoria: Categoria,
+  // `nullable` y no `optional`: el modo estricto de salida estructurada de
+  // OpenAI exige que TODAS las propiedades estén en `required`, y un campo
+  // opcional queda afuera —la API rechaza la llamada entera con
+  // "Missing 'unidad_reportada_texto'"—. Nullable expresa lo mismo de una forma
+  // que el modo estricto acepta: el campo siempre viene, con null cuando no
+  // aplica. Esto es lo que hacía que el clasificador real no funcionara nunca,
+  // y solo se podía descubrir con una API key de verdad.
   unidad_reportada_texto: z
     .string()
     .max(60)
-    .optional()
-    .describe('Solo en CONDUCTA: la unidad del vecino señalado, tal como la escribió el residente'),
+    .nullable()
+    .describe('Solo en CONDUCTA: la unidad del vecino señalado, tal como la escribió el residente. null si no aplica'),
   origen: Origen,
   urgencia: Urgencia,
-  ubicacion: z.string().max(200).optional().describe('Dónde ocurre, si el reporte lo menciona'),
+  ubicacion: z
+    .string()
+    .max(200)
+    .nullable()
+    .describe('Dónde ocurre, si el reporte lo menciona. null si no lo dice'),
   confianza: z.number().min(0).max(1).describe('Qué tan seguro está el modelo de esta clasificación'),
 });
 export type ClassifierModelOutput = z.infer<typeof ClassifierModelOutput>;
@@ -54,10 +65,12 @@ export const ClassifierOutput = z.object({
   descripcion_normalizada: z.string().min(1).max(2000),
   tipo: TipoTicket,
   categoria: Categoria,
-  unidad_reportada_texto: z.string().max(60).optional(),
+  // Acepta ausente y null: el modelo real manda null explícito, y el mock —o un
+  // registro viejo— puede omitirlo.
+  unidad_reportada_texto: z.string().max(60).nullish(),
   origen: Origen,
   urgencia: Urgencia,
-  ubicacion: z.string().max(200).optional(),
+  ubicacion: z.string().max(200).nullish(),
   confianza: z.number().min(0).max(1),
   modelo: z.string(),
   prompt_version: z.string(),

--- a/packages/ai/src/schemas.ts
+++ b/packages/ai/src/schemas.ts
@@ -33,6 +33,17 @@ export type Categoria = z.infer<typeof Categoria>;
  * una fuente de alucinación.
  */
 export const ClassifierModelOutput = z.object({
+  /**
+   * Si el mensaje no contiene ningún problema que registrar.
+   *
+   * Sin este campo el modelo está obligado a clasificar cualquier texto, así que
+   * lo inventa: un "Gracias" salía como "Agujero en el techo del pasillo", con
+   * urgencia alta, listo para ensuciar la bandeja de la administración. Un
+   * clasificador que no puede abstenerse alucina.
+   */
+  es_reporte: z
+    .boolean()
+    .describe('false si el mensaje no describe ningún problema (saludos, gracias, preguntas, charla)'),
   titulo: z.string().min(3).max(140).describe('Título corto y descriptivo del reporte'),
   descripcion_normalizada: z.string().min(1).max(2000).describe('El reporte reescrito de forma clara y neutra'),
   tipo: TipoTicket.describe('CONDUCTA si se queja del comportamiento de un vecino; si no, INFRAESTRUCTURA'),
@@ -61,6 +72,9 @@ export const ClassifierModelOutput = z.object({
 export type ClassifierModelOutput = z.infer<typeof ClassifierModelOutput>;
 
 export const ClassifierOutput = z.object({
+  // Los registros anteriores a este campo no lo tienen: se asume que sí eran
+  // reportes, porque llegaron a crear un ticket.
+  es_reporte: z.boolean().default(true),
   titulo: z.string().min(3).max(140),
   descripcion_normalizada: z.string().min(1).max(2000),
   tipo: TipoTicket,

--- a/packages/ai/src/schemas.ts
+++ b/packages/ai/src/schemas.ts
@@ -28,22 +28,38 @@ export type TipoTicket = z.infer<typeof TipoTicket>;
 export type Categoria = z.infer<typeof Categoria>;
 
 /**
+ * Qué está haciendo el vecino con este mensaje.
+ *
+ * Reemplaza al `es_reporte` booleano: decía "esto no es un reporte" pero no
+ * decía qué sí era, así que a una pregunta legítima —"¿cuál fue el último
+ * registro?"— el bot contestaba "no encontré un problema para registrar", que es
+ * cierto y a la vez inútil. Un solo campo en lugar de un booleano más un enum
+ * porque dos campos que contestan la misma pregunta se desincronizan.
+ *
+ * `OTRO` es el cajón de lo que no hay que accionar: cortesías, charla, cualquier
+ * cosa fuera del alcance del bot.
+ */
+export const Intencion = z.enum(['REPORTE', 'CONSULTA_ESTADO', 'AYUDA', 'OTRO']);
+export type Intencion = z.infer<typeof Intencion>;
+
+/**
  * Lo que devuelve el MODELO. `modelo` y `prompt_version` no los produce el LLM:
  * los agrega el adaptador, así que pedírselos al modelo sería a la vez inútil y
  * una fuente de alucinación.
  */
 export const ClassifierModelOutput = z.object({
   /**
-   * Si el mensaje no contiene ningún problema que registrar.
+   * Qué quiere el vecino. Va primero porque decide si el resto de los campos
+   * significan algo.
    *
-   * Sin este campo el modelo está obligado a clasificar cualquier texto, así que
-   * lo inventa: un "Gracias" salía como "Agujero en el techo del pasillo", con
+   * Sin esto el modelo está obligado a clasificar cualquier texto, así que lo
+   * inventa: un "Gracias" salía como "Agujero en el techo del pasillo", con
    * urgencia alta, listo para ensuciar la bandeja de la administración. Un
    * clasificador que no puede abstenerse alucina.
    */
-  es_reporte: z
-    .boolean()
-    .describe('false si el mensaje no describe ningún problema (saludos, gracias, preguntas, charla)'),
+  intencion: Intencion.describe(
+    'REPORTE si describe un problema a registrar; CONSULTA_ESTADO si pregunta por sus reportes; AYUDA si pregunta qué podés hacer; OTRO para saludos, gracias y charla',
+  ),
   titulo: z.string().min(3).max(140).describe('Título corto y descriptivo del reporte'),
   descripcion_normalizada: z.string().min(1).max(2000).describe('El reporte reescrito de forma clara y neutra'),
   tipo: TipoTicket.describe('CONDUCTA si se queja del comportamiento de un vecino; si no, INFRAESTRUCTURA'),
@@ -72,9 +88,9 @@ export const ClassifierModelOutput = z.object({
 export type ClassifierModelOutput = z.infer<typeof ClassifierModelOutput>;
 
 export const ClassifierOutput = z.object({
-  // Los registros anteriores a este campo no lo tienen: se asume que sí eran
+  // Los registros anteriores a este campo no lo tienen: se asume que eran
   // reportes, porque llegaron a crear un ticket.
-  es_reporte: z.boolean().default(true),
+  intencion: Intencion.default('REPORTE'),
   titulo: z.string().min(3).max(140),
   descripcion_normalizada: z.string().min(1).max(2000),
   tipo: TipoTicket,

--- a/packages/domain/src/rbac/policies.test.ts
+++ b/packages/domain/src/rbac/policies.test.ts
@@ -129,24 +129,53 @@ describe('canResidenteSeeCosto (G10)', () => {
     expect(canResidenteSeeCosto(propietarioDeB, comun)).toBe(true);
   });
 
-  it('costo de ticket de UNIDAD: privado, no visible (ni para el ocupante)', () => {
-    const unidadTicket = {
-      tipo: 'INFRAESTRUCTURA' as const,
-      origen: 'UNIDAD' as const,
-      unidadId: unidadA,
-      consorcioId: cons1,
-    };
-    expect(canResidenteSeeCosto(propietarioDeA, unidadTicket)).toBe(false);
+  // Decisión 2026-08-18: antes esto exigía `false` incluso para el ocupante, y
+  // dejaba el sistema incoherente — el admin podía cargar la factura del plomero
+  // en un ticket de unidad y después NADIE salvo él podía verla nunca, ni quien
+  // la paga. G10 protege el costo privado del *resto* del consorcio.
+  const unidadTicket = {
+    tipo: 'INFRAESTRUCTURA' as const,
+    origen: 'UNIDAD' as const,
+    unidadId: unidadA,
+    consorcioId: cons1,
+  };
+
+  it('costo de ticket de UNIDAD: visible a los ocupantes de esa unidad', () => {
+    expect(canResidenteSeeCosto(propietarioDeA, unidadTicket)).toBe(true);
+    expect(canResidenteSeeCosto(inquilinoDeA, unidadTicket)).toBe(true);
   });
 
-  it('costo de ticket de CONDUCTA: nunca visible', () => {
+  it('costo de ticket de UNIDAD: oculto al resto del consorcio', () => {
+    expect(canResidenteSeeCosto(propietarioDeB, unidadTicket)).toBe(false);
+  });
+
+  it('costo de UNIDAD: ser el reportante no alcanza si no se ocupa la unidad', () => {
+    // Un vecino puede reportar la filtración del 1A; eso no le da la factura del 1A.
+    const reportadoPorVecino = { ...unidadTicket, reportanteId: propietarioDeB.residenteId };
+    expect(canResidenteSeeTicket(propietarioDeB, reportadoPorVecino)).toBe(true);
+    expect(canResidenteSeeCosto(propietarioDeB, reportadoPorVecino)).toBe(false);
+  });
+
+  it('costo con origen sin validar: se trata como UNIDAD, no se publica', () => {
+    const sinValidar = { ...unidadTicket, origen: null };
+    expect(canResidenteSeeCosto(propietarioDeA, sinValidar)).toBe(true);
+    expect(canResidenteSeeCosto(propietarioDeB, sinValidar)).toBe(false);
+  });
+
+  it('costo de ticket de CONDUCTA: nunca visible, ni al acusado ni al denunciante', () => {
     const conducta = {
       tipo: 'CONDUCTA' as const,
       origen: null,
       unidadId: unidadA,
+      unidadReportadaId: unidadA,
       consorcioId: cons1,
     };
+    // El acusado ve el ticket pero no el monto: publicar la sanción en pesos lo
+    // vuelve parte del conflicto entre vecinos (G11).
+    expect(canResidenteSeeTicket(propietarioDeA, conducta)).toBe(true);
     expect(canResidenteSeeCosto(propietarioDeA, conducta)).toBe(false);
+    const denunciante = { ...conducta, reportanteId: propietarioDeB.residenteId };
+    expect(canResidenteSeeCosto(propietarioDeB, denunciante)).toBe(false);
   });
 
   it('residente de otro consorcio no ve el costo común', () => {

--- a/packages/domain/src/rbac/policies.ts
+++ b/packages/domain/src/rbac/policies.ts
@@ -87,11 +87,30 @@ export function canResidenteSeeTicket(
  *
  * Presupuestos/borradores no se consideran acá: el caller debe filtrar por
  * gasto.estado = CONFIRMADO antes de exponer montos.
+ *
+ * Los costos de una unidad NO son públicos, pero sí son visibles para los
+ * ocupantes de ESA unidad: son quienes pagan la reparación de su propio
+ * departamento. Hasta 2026-08-18 esta función devolvía `false` para todo lo que
+ * no fuera ESPACIO_COMUN, así que el propietario del 1A reportaba una pérdida
+ * en su baño, el admin cargaba la factura del plomero, y el propietario recibía
+ * un 404 al pedir el monto: la app no tenía forma de mostrarle lo que debía.
+ * G10 existe para que el costo privado no se filtre al *resto* del consorcio,
+ * no para ocultárselo al afectado.
  */
 export function canResidenteSeeCosto(
   user: ResidenteCtx,
   ticket: TicketVisibilityCtx,
 ): boolean {
   if (!canResidenteSeeTicket(user, ticket)) return false;
-  return ticket.tipo === 'INFRAESTRUCTURA' && ticket.origen === 'ESPACIO_COMUN';
+  // CONDUCTA: el costo de una sanción o de un arreglo por daños queda solo para
+  // el admin. Publicárselo al denunciado o al denunciante convierte el monto en
+  // parte del conflicto entre vecinos (G11).
+  if (ticket.tipo !== 'INFRAESTRUCTURA') return false;
+  // Espacio común: transparencia total, es la propuesta de valor (G10).
+  if (ticket.origen === 'ESPACIO_COMUN') return true;
+  // UNIDAD (y origen todavía sin validar, que se trata como UNIDAD por defecto
+  // seguro): solo ocupantes de la unidad afectada. Ojo, no alcanza con ser el
+  // reportante: un vecino puede reportar la filtración del 1A y no por eso ve
+  // la factura del 1A.
+  return ticket.unidadId !== null && user.unidadIds.has(ticket.unidadId);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.43)(terser@5.48.0)
 
   apps/worker:
     dependencies:
@@ -1836,7 +1839,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.16.0)(@types/node@20.19.43)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.4
       typescript:
         specifier: ^5.6.0
         version: 5.9.3

--- a/scripts/telegram-tunel-fijo.sh
+++ b/scripts/telegram-tunel-fijo.sh
@@ -98,25 +98,89 @@ YAML
 echo "configuración escrita en ${CONFIG}"
 echo "  publicada: /webhooks/telegram   ·   el resto de la API: 404"
 
+# ── El túnel primero, el webhook después ─────────────────────────────────────
+#
+# Telegram valida el host al registrar el webhook: si el túnel no está arriba o el
+# DNS todavía no se propagó a sus resolvers, responde
+# "Failed to resolve host: Name or service not known". Registrarlo antes de
+# levantar el túnel —como hacía la primera versión de este script— falla siempre.
+echo "levantando el túnel…"
+cloudflared tunnel --config "$CONFIG" run &
+CF_PID=$!
+trap 'kill "$CF_PID" 2>/dev/null || true' EXIT
+
+# Se espera a que la URL pública conteste de verdad. Un 401 es la respuesta
+# correcta: significa que el pedido llegó hasta la API y esta lo rechazó por
+# venir sin el header secreto, o sea que la cadena entera funciona
+# —DNS → Cloudflare → túnel → API—. Un 404 sería el borde de Cloudflare
+# respondiendo sin llegar acá, y un error de conexión, DNS sin propagar.
+echo "esperando a que https://${HOSTNAME_PUBLICO} responda…"
+LISTO=""
+for _ in $(seq 1 60); do
+  CODIGO="$(curl -s -o /dev/null -m 5 -w '%{http_code}' \
+    -X POST "https://${HOSTNAME_PUBLICO}/webhooks/telegram" \
+    -H 'content-type: application/json' -d '{}' || true)"
+  if [[ "$CODIGO" == "401" ]]; then LISTO="si"; break; fi
+  if ! kill -0 "$CF_PID" 2>/dev/null; then
+    echo "el túnel se cerró solo" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+if [[ -z "$LISTO" ]]; then
+  echo "la URL pública no contestó como se esperaba (último código: ${CODIGO:-sin respuesta})." >&2
+  echo "Si es un 404, la regla de ingress no matcheó. Si no hay respuesta, el DNS" >&2
+  echo "todavía no se propagó: esperá un minuto y volvé a correr el script." >&2
+  exit 1
+fi
+echo "  responde 401 sin el secreto: la cadena DNS → Cloudflare → túnel → API funciona"
+
+# Y se comprueba que el resto de la API NO esté publicada, que es el punto de la
+# regla de ingress. Sin esto la restricción sería una intención, no un hecho.
+CODIGO_LOGIN="$(curl -s -o /dev/null -m 8 -w '%{http_code}' \
+  -X POST "https://${HOSTNAME_PUBLICO}/auth/login" \
+  -H 'content-type: application/json' -d '{"email":"x@x.com","password":"x"}' || true)"
+if [[ "$CODIGO_LOGIN" == "404" ]]; then
+  echo "  /auth/login devuelve 404 desde afuera: el resto de la API queda privada"
+else
+  echo "  CUIDADO: /auth/login respondió ${CODIGO_LOGIN} desde internet, debería ser 404." >&2
+  echo "  Revisá la regla de ingress en ${CONFIG} antes de dejar esto abierto." >&2
+fi
+
 if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && -n "${TELEGRAM_WEBHOOK_SECRET:-}" ]]; then
   echo "registrando el webhook (una sola vez: la URL ya no cambia)…"
-  RESP="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
-    -d "url=https://${HOSTNAME_PUBLICO}/webhooks/telegram" \
-    -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
-    -d 'drop_pending_updates=true')"
-  if grep -q '"ok":true' <<<"$RESP"; then
-    echo "  webhook OK → https://${HOSTNAME_PUBLICO}/webhooks/telegram"
-  else
+  # Sin `-f` y sin abortar por `set -e`: cuando Telegram rechaza algo, el motivo
+  # viene en el cuerpo de la respuesta y es justo lo que hay que mostrar. Con
+  # `curl -fsS` dentro de una sustitución, `set -e` mataba el script acá y el
+  # manejo de error de abajo nunca corría.
+  for intento in 1 2 3 4 5; do
+    RESP="$(curl -s -m 15 "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+      -d "url=https://${HOSTNAME_PUBLICO}/webhooks/telegram" \
+      -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+      -d 'drop_pending_updates=true' || echo '{"ok":false,"description":"curl falló"}')"
+    if grep -q '"ok":true' <<<"$RESP"; then
+      echo "  webhook OK → https://${HOSTNAME_PUBLICO}/webhooks/telegram"
+      break
+    fi
+    # El DNS recién creado tarda en llegar a los resolvers de Telegram, así que
+    # este caso puntual se reintenta en vez de darse por perdido.
+    if grep -qi "resolve host" <<<"$RESP" && [[ $intento -lt 5 ]]; then
+      echo "  Telegram todavía no resuelve el host, reintento en 20s (intento ${intento}/5)…"
+      sleep 20
+      continue
+    fi
     echo "  Telegram rechazó el webhook: $RESP" >&2
-  fi
+    break
+  done
 else
   echo "sin TELEGRAM_BOT_TOKEN / TELEGRAM_WEBHOOK_SECRET en el .env:"
   echo "  el túnel igual queda arriba, pero el webhook hay que registrarlo después."
 fi
 
 echo
-echo "túnel corriendo. Escribile a tu bot desde Telegram."
+echo "túnel corriendo. Escribile a @Consorfix_bot desde Telegram."
 echo "  Mientras esté abierto podés cambiar todo el código: la API recompila sola."
 echo "  Ctrl+C para cerrarlo."
 echo
-exec cloudflared tunnel --config "$CONFIG" run
+wait "$CF_PID"

--- a/scripts/telegram-tunel-fijo.sh
+++ b/scripts/telegram-tunel-fijo.sh
@@ -1,28 +1,35 @@
 #!/usr/bin/env bash
 #
-# Túnel con nombre y URL permanente, más el webhook de Telegram registrado una
-# sola vez.
+# Túnel con nombre y URL permanente que expone **solo el webhook de Telegram**,
+# más el `setWebhook` registrado una sola vez.
 #
-#   ./scripts/telegram-tunel-fijo.sh consorfix.tu-dominio.com
+#   ./scripts/telegram-tunel-fijo.sh consorfix-bot.tu-dominio.com
+#
+# Por qué solo esa ruta: el túnel publica en internet lo que apunta, y apuntar
+# `localhost:3003` entero deja `/auth/login` accesible desde afuera con la base de
+# desarrollo detrás —usuarios del seed, contraseñas de ejemplo—. Y la URL no es un
+# secreto: los subdominios aparecen en los logs públicos de Certificate
+# Transparency, así que "nadie la va a encontrar" no es una defensa. Con una regla
+# de ingress por path, todo lo que no sea el webhook devuelve 404 en el borde de
+# Cloudflare y nunca llega a esta máquina.
 #
 # La diferencia con `telegram-tunel.sh`: ese abre un túnel rápido con URL
-# aleatoria y vuelve a registrar el webhook en cada arranque. Este usa un
-# hostname propio, así que la URL no cambia nunca: el `setWebhook` se corre una
-# vez y después reiniciar el túnel, la Mac o la API no obliga a tocar nada.
+# aleatoria y vuelve a registrar el webhook en cada arranque. Este usa un hostname
+# propio, así que la URL no cambia nunca.
 #
-# Requiere un dominio con DNS en Cloudflare y `cloudflared tunnel login` hecho
-# (existe ~/.cloudflared/cert.pem). No tiene el límite de una sesión simultánea
-# del plan gratis de ngrok, así que convive con otros túneles de la misma cuenta.
+# Requiere un dominio con DNS en Cloudflare y `cloudflared tunnel login` hecho.
+# No tiene el límite de una sesión simultánea del plan gratis de ngrok.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
 HOSTNAME_PUBLICO="${1:-}"
 NOMBRE_TUNEL="${TUNEL_NOMBRE:-consorciofix}"
+CONFIG="${HOME}/.cloudflared/${NOMBRE_TUNEL}.yml"
 
 if [[ -z "$HOSTNAME_PUBLICO" ]]; then
   echo "uso: $0 <hostname>" >&2
-  echo "ej:  $0 consorfix.tu-dominio.com" >&2
+  echo "ej:  $0 consorfix-bot.tu-dominio.com" >&2
   exit 1
 fi
 
@@ -43,8 +50,7 @@ if ! curl -fsS -m 4 "http://localhost:${PUERTO}/health" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Crear el túnel solo si no existe: el script tiene que poder correrse muchas
-# veces sin acumular túneles ni fallar en el segundo intento.
+# Idempotente: un script de entorno que falla la segunda vez que se corre no sirve.
 if cloudflared tunnel list 2>/dev/null | grep -qE "[[:space:]]${NOMBRE_TUNEL}[[:space:]]"; then
   echo "el túnel '${NOMBRE_TUNEL}' ya existe, lo reuso"
 else
@@ -52,20 +58,48 @@ else
   cloudflared tunnel create "$NOMBRE_TUNEL"
 fi
 
-# Igual con el DNS: si el registro ya apunta a este túnel, Cloudflare devuelve un
-# error que acá no es un problema.
+UUID="$(cloudflared tunnel list --output json 2>/dev/null \
+  | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
+      const t=JSON.parse(s).find(x=>x.name===process.argv[1]);
+      process.stdout.write(t?t.id:'');
+    })" "$NOMBRE_TUNEL")"
+
+if [[ -z "$UUID" ]]; then
+  echo "no pude resolver el id del túnel '${NOMBRE_TUNEL}'" >&2
+  exit 1
+fi
+
 echo "apuntando ${HOSTNAME_PUBLICO} al túnel…"
-if ! cloudflared tunnel route dns "$NOMBRE_TUNEL" "$HOSTNAME_PUBLICO" 2>&1 | tee /tmp/cfx-dns.log; then
-  if grep -qiE "already exists|record with that host" /tmp/cfx-dns.log; then
+if ! cloudflared tunnel route dns "$NOMBRE_TUNEL" "$HOSTNAME_PUBLICO" >/tmp/cfx-dns.log 2>&1; then
+  if grep -qiE "already exists|record with that host|already configured" /tmp/cfx-dns.log; then
     echo "  (el registro ya existía, sigo)"
   else
     echo "no pude crear el registro DNS. ¿El dominio está en Cloudflare?" >&2
+    cat /tmp/cfx-dns.log >&2
     exit 1
   fi
 fi
 
+# La regla de ingress es lo que limita la exposición: solo el webhook llega a esta
+# máquina, el resto muere en el borde con un 404.
+cat > "$CONFIG" <<YAML
+# Generado por scripts/telegram-tunel-fijo.sh — se reescribe en cada corrida.
+tunnel: ${UUID}
+credentials-file: ${HOME}/.cloudflared/${UUID}.json
+
+ingress:
+  # Única ruta publicada. Todo lo demás de la API queda privado.
+  - hostname: ${HOSTNAME_PUBLICO}
+    path: ^/webhooks/telegram/?$
+    service: http://localhost:${PUERTO}
+  - service: http_status:404
+YAML
+
+echo "configuración escrita en ${CONFIG}"
+echo "  publicada: /webhooks/telegram   ·   el resto de la API: 404"
+
 if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && -n "${TELEGRAM_WEBHOOK_SECRET:-}" ]]; then
-  echo "registrando el webhook de Telegram (una sola vez: la URL ya no cambia)…"
+  echo "registrando el webhook (una sola vez: la URL ya no cambia)…"
   RESP="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
     -d "url=https://${HOSTNAME_PUBLICO}/webhooks/telegram" \
     -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
@@ -81,8 +115,8 @@ else
 fi
 
 echo
-echo "túnel corriendo. https://${HOSTNAME_PUBLICO} → localhost:${PUERTO}"
+echo "túnel corriendo. Escribile a tu bot desde Telegram."
 echo "  Mientras esté abierto podés cambiar todo el código: la API recompila sola."
 echo "  Ctrl+C para cerrarlo."
 echo
-exec cloudflared tunnel run --url "http://localhost:${PUERTO}" "$NOMBRE_TUNEL"
+exec cloudflared tunnel --config "$CONFIG" run

--- a/scripts/telegram-tunel-fijo.sh
+++ b/scripts/telegram-tunel-fijo.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Túnel con nombre y URL permanente, más el webhook de Telegram registrado una
+# sola vez.
+#
+#   ./scripts/telegram-tunel-fijo.sh consorfix.tu-dominio.com
+#
+# La diferencia con `telegram-tunel.sh`: ese abre un túnel rápido con URL
+# aleatoria y vuelve a registrar el webhook en cada arranque. Este usa un
+# hostname propio, así que la URL no cambia nunca: el `setWebhook` se corre una
+# vez y después reiniciar el túnel, la Mac o la API no obliga a tocar nada.
+#
+# Requiere un dominio con DNS en Cloudflare y `cloudflared tunnel login` hecho
+# (existe ~/.cloudflared/cert.pem). No tiene el límite de una sesión simultánea
+# del plan gratis de ngrok, así que convive con otros túneles de la misma cuenta.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+HOSTNAME_PUBLICO="${1:-}"
+NOMBRE_TUNEL="${TUNEL_NOMBRE:-consorciofix}"
+
+if [[ -z "$HOSTNAME_PUBLICO" ]]; then
+  echo "uso: $0 <hostname>" >&2
+  echo "ej:  $0 consorfix.tu-dominio.com" >&2
+  exit 1
+fi
+
+if [[ ! -f "$HOME/.cloudflared/cert.pem" ]]; then
+  echo "falta autorizar cloudflared con tu cuenta: cloudflared tunnel login" >&2
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  echo "no encuentro el .env en la raíz del repo" >&2
+  exit 1
+fi
+set -a && . ./.env && set +a
+PUERTO="${API_PORT:-3000}"
+
+if ! curl -fsS -m 4 "http://localhost:${PUERTO}/health" >/dev/null 2>&1; then
+  echo "la API no responde en localhost:${PUERTO} — levantala antes" >&2
+  exit 1
+fi
+
+# Crear el túnel solo si no existe: el script tiene que poder correrse muchas
+# veces sin acumular túneles ni fallar en el segundo intento.
+if cloudflared tunnel list 2>/dev/null | grep -qE "[[:space:]]${NOMBRE_TUNEL}[[:space:]]"; then
+  echo "el túnel '${NOMBRE_TUNEL}' ya existe, lo reuso"
+else
+  echo "creando el túnel '${NOMBRE_TUNEL}'…"
+  cloudflared tunnel create "$NOMBRE_TUNEL"
+fi
+
+# Igual con el DNS: si el registro ya apunta a este túnel, Cloudflare devuelve un
+# error que acá no es un problema.
+echo "apuntando ${HOSTNAME_PUBLICO} al túnel…"
+if ! cloudflared tunnel route dns "$NOMBRE_TUNEL" "$HOSTNAME_PUBLICO" 2>&1 | tee /tmp/cfx-dns.log; then
+  if grep -qiE "already exists|record with that host" /tmp/cfx-dns.log; then
+    echo "  (el registro ya existía, sigo)"
+  else
+    echo "no pude crear el registro DNS. ¿El dominio está en Cloudflare?" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && -n "${TELEGRAM_WEBHOOK_SECRET:-}" ]]; then
+  echo "registrando el webhook de Telegram (una sola vez: la URL ya no cambia)…"
+  RESP="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+    -d "url=https://${HOSTNAME_PUBLICO}/webhooks/telegram" \
+    -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+    -d 'drop_pending_updates=true')"
+  if grep -q '"ok":true' <<<"$RESP"; then
+    echo "  webhook OK → https://${HOSTNAME_PUBLICO}/webhooks/telegram"
+  else
+    echo "  Telegram rechazó el webhook: $RESP" >&2
+  fi
+else
+  echo "sin TELEGRAM_BOT_TOKEN / TELEGRAM_WEBHOOK_SECRET en el .env:"
+  echo "  el túnel igual queda arriba, pero el webhook hay que registrarlo después."
+fi
+
+echo
+echo "túnel corriendo. https://${HOSTNAME_PUBLICO} → localhost:${PUERTO}"
+echo "  Mientras esté abierto podés cambiar todo el código: la API recompila sola."
+echo "  Ctrl+C para cerrarlo."
+echo
+exec cloudflared tunnel run --url "http://localhost:${PUERTO}" "$NOMBRE_TUNEL"

--- a/scripts/telegram-tunel.sh
+++ b/scripts/telegram-tunel.sh
@@ -58,6 +58,15 @@ if [[ -z "$URL" ]]; then
 fi
 
 echo "túnel arriba: $URL"
+echo
+echo "  OJO: un túnel rápido publica la API ENTERA, no solo el webhook. Mientras"
+echo "  esté abierto, esa URL llega a /auth/login con tu base de desarrollo"
+echo "  detrás. El riesgo es acotado —el subdominio es aleatorio, va bajo un"
+echo "  certificado comodín (no queda en los logs de Certificate Transparency) y"
+echo "  muere al cerrar esto— pero cerralo cuando termines."
+echo "  Para algo permanente usá telegram-tunel-fijo.sh, que publica solo el"
+echo "  webhook y deja el resto de la API en 404."
+echo
 echo "registrando el webhook…"
 
 RESP="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \

--- a/scripts/telegram-tunel.sh
+++ b/scripts/telegram-tunel.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Abre un túnel público a la API y registra el webhook de Telegram con esa URL.
+#
+# El túnel rápido de cloudflared no necesita cuenta ni tiene límite de sesiones
+# simultáneas —a diferencia del plan gratis de ngrok, que permite un solo agente
+# a la vez—, pero cada vez que arranca da una URL aleatoria. Esto lee esa URL de
+# su propia salida y corre `setWebhook` solo, así que reiniciarlo deja de ser un
+# trámite: un comando y Telegram vuelve a apuntar donde tiene que apuntar.
+#
+#   ./scripts/telegram-tunel.sh
+#
+# Necesita TELEGRAM_BOT_TOKEN y TELEGRAM_WEBHOOK_SECRET en el .env.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ ! -f .env ]]; then
+  echo "no encuentro el .env en la raíz del repo" >&2
+  exit 1
+fi
+set -a && . ./.env && set +a
+
+: "${TELEGRAM_BOT_TOKEN:?falta TELEGRAM_BOT_TOKEN en el .env (te lo da @BotFather)}"
+: "${TELEGRAM_WEBHOOK_SECRET:?falta TELEGRAM_WEBHOOK_SECRET en el .env (lo elegís vos)}"
+PUERTO="${API_PORT:-3000}"
+
+if ! curl -fsS -m 4 "http://localhost:${PUERTO}/health" >/dev/null 2>&1; then
+  echo "la API no responde en localhost:${PUERTO} — levantala antes" >&2
+  exit 1
+fi
+
+SALIDA="$(mktemp -t cfx-tunel)"
+trap 'kill "${CF_PID:-0}" 2>/dev/null || true; rm -f "$SALIDA"' EXIT
+
+echo "abriendo el túnel a localhost:${PUERTO}…"
+cloudflared tunnel --url "http://localhost:${PUERTO}" --no-autoupdate >"$SALIDA" 2>&1 &
+CF_PID=$!
+
+# La URL aparece en la salida a los pocos segundos. Se espera en vez de dormir un
+# rato fijo: en una conexión lenta un sleep corto falla y uno largo molesta.
+URL=""
+for _ in $(seq 1 40); do
+  URL="$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$SALIDA" | head -1 || true)"
+  [[ -n "$URL" ]] && break
+  if ! kill -0 "$CF_PID" 2>/dev/null; then
+    echo "cloudflared se cerró antes de dar una URL:" >&2
+    tail -5 "$SALIDA" >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+if [[ -z "$URL" ]]; then
+  echo "no pude leer la URL del túnel. Últimas líneas:" >&2
+  tail -10 "$SALIDA" >&2
+  exit 1
+fi
+
+echo "túnel arriba: $URL"
+echo "registrando el webhook…"
+
+RESP="$(curl -fsS "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  -d "url=${URL}/webhooks/telegram" \
+  -d "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+  -d 'drop_pending_updates=true')"
+
+if ! grep -q '"ok":true' <<<"$RESP"; then
+  echo "Telegram rechazó el webhook:" >&2
+  echo "$RESP" >&2
+  exit 1
+fi
+
+echo
+echo "listo. Escribile a tu bot desde Telegram."
+echo "  El túnel queda abierto acá: si cerrás esta terminal, se cierra."
+echo "  Mientras siga abierto podés cambiar todo el código que quieras —"
+echo "  la API recompila sola y Telegram no se entera."
+echo
+echo "Ctrl+C para cerrar el túnel."
+wait "$CF_PID"

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
     "JWT_ACCESS_TTL",
     "JWT_REFRESH_TTL",
     "REDIS_URL",
+    "ADMIN_WEB_PORT",
     "API_PORT",
     "API_HOST",
     "API_URL",


### PR DESCRIPTION
Probé la aplicación entera en runtime —roles, pertenencia a consorcios, permisos por consorcio, invitaciones— y arreglé todo lo que encontré roto o a medio terminar. Cinco commits, cada uno con su verificación.

## Los dos que rompían funciones completas

**No se podía validar un ticket de conducta desde el panel.** El panel nunca mandaba `unidad_reportada_id`, que la API exige para validar una CONDUCTA (con un CHECK en la base que lo respalda, migración 0004). El botón "Confirmar validación" fallaba **siempre**: una denuncia que entraba por el bot no se podía procesar nunca, y todo el circuito de RF-F01 —construido en el PR #37— era inalcanzable desde la UI.

**La sanción se registraba contra la unidad del denunciante.** `POST /tickets/:id/registros-conducta` escribía contra `ticket.unidad_id`, que desde la 0004 dejó de ser la unidad acusada: en un ticket creado por el bot es la unidad de **quien denuncia**, porque el bot imputa la unidad del que escribe. El admin registraba un aviso o una sanción y le quedaba asentada al vecino que hizo la denuncia, en su propio historial de convivencia (RF-F03).

Confirmé que el test lo detecta y no pasa en vacío: con el código viejo falla (registra contra 2B en vez de 1A), con el arreglo pasa. La primera versión del test sí pasaba en vacío porque el fixture usaba la misma unidad en los dos campos; lo rearmé como lo manda el bot.

## Datos inventados que se leían como reales

El panel de "Sugerencia de la IA" mostraba un **`85%` de confianza escrito en el código**, y la "categoría sugerida" la derivaba de `ticket.origen` — o sea de la decisión que el admin ya había tomado. La regla 4 dice "la IA sugiere, el admin decide", y decidía mirando un número inventado.

Ahora `GET /tickets/:id` expone `clasificacion_ia` (solo a admins: en conducta el `sugerido` contiene el texto crudo del denunciante y la unidad que dedujo el modelo) y el panel muestra lo real — confianza, tipo, origen y categoría sugeridos, modelo, versión del prompt y si fue corregida. También `categoria_id` estaba en el cliente y ninguna pantalla lo mandaba, así que la corrección del admin (RF-C04) no se registraba nunca.

## Lo que salió de probar, no de leer

Escenario con 2 administraciones, 3 consorcios, 4 unidades y 8 actores (super admin, 2 admins, residentes con 1 y con 2 consorcios, uno de otra administración), contra **111 aserciones por HTTP**. Pasaron 109:

- **El costo de la propia unidad estaba oculto a sus ocupantes.** `canResidenteSeeCosto` devolvía `false` para todo lo que no fuera ESPACIO_COMUN: el admin cargaba la factura del plomero en un ticket de unidad y nadie salvo él podía verla nunca, tampoco quien la paga. G10 protege el costo privado del *resto* del consorcio, no se lo oculta al afectado. Este comportamiento estaba **deliberado** (el test decía "ni para el ocupante"), así que la razón del cambio queda registrada en la policy y en el test.
- **`PATCH /consorcios/:id` sobre un consorcio ajeno devolvía 200 con body vacío.** No filtraba datos —el WHERE acota por `tenant_id`, el UPDATE tocaba 0 filas— pero el panel mostraba "guardado" sin haber guardado nada. Ahora 404, igual que `vinculos.update`, que ya lo hacía bien.

Después de todos los cambios la matriz vuelve a dar **111/111**.

## Controles muertos

Cinco no hacían nada: el buscador global del topbar con un `⌘K` dibujado que no existía en ningún listener, "Exportar", "Nuevo reporte", "Notificar vecinos", y en la app el botón de votar aparecía en las conductas (la API las rechaza con 403, así que el denunciado veía "Sumar voto" sobre la denuncia hecha en su contra).

Exportar y Nuevo reporte ahora funcionan. El buscador global se reemplazó por uno real en la bandeja, que es donde hay algo que buscar. "Notificar vecinos" se saca: el sistema no tiene aviso manual, los avisos salen solos en cada transición — ahora linkea al historial de envíos del ticket.

## Funcionalidad que existía sin pantalla

Historial del ticket (RF-D02), gastos en BORRADOR, telemetría de costo de IA en métricas (RF-C07, incluida la tasa de corrección del admin), importar CSV (RF-A05), crear administración (RF-A01), editar y archivar consorcio, alta masiva de unidades, avisos y sanciones con el historial de convivencia por unidad (RF-F03), los **costos confirmados en la app** —la propuesta de valor del producto, invisible para el vecino— y el alta de inquilino por el propietario, que CLAUDE.md pide explícitamente desde la app.

Al escribir la UI del historial encontré que mi propio tipo del cliente no coincidía con la respuesta (`id`/`tipo`/`createdAt` contra `transicion`/`at`): `apiFetch<T>` es un cast, así que TypeScript no ve nada y se habría renderizado vacío. Comparé **todas** las interfaces del cliente contra las respuestas reales; era la única desfasada.

## Cola offline

Decía "se enviará cuando vuelva la red" y no había nada que lo hiciera: `syncQueue` solo corría si el vecino apretaba el botón. Y cualquier error reencolaba, así que un rechazo definitivo del servidor —un 403 porque le dieron de baja el vínculo mientras estaba sin señal— se reintentaba para siempre y hacía fallar todas las sincronizaciones siguientes.

Ahora se sincroniza al abrir la pantalla y cuando la app vuelve al frente (`AppState`, sin sumar netinfo: escuchar la conectividad de verdad es mejor pero no puedo probarlo sin dispositivo, y prefiero algo que sé que funciona). Y se distingue lo transitorio (red, 5xx, 408, 429) de lo definitivo: lo rechazado no se reintenta más y tampoco se borra solo, queda visible con el motivo y un botón para descartarlo, porque el vecino escribió ese texto.

## Otros

- `GET /tickets` mandaba el `embedding` (384 floats, ~877 bytes por ticket) que ningún cliente usa: era el **47%** del peso de la respuesta con tickets del bot. Medido antes y después: 48% menos.
- El `dry_run` del import contaba la misma unidad nueva una vez por fila, así que una planilla con propietario + inquilino por unidad informaba el doble de unidades a crear — y el admin usa esa vista previa para decidir.
- Las credenciales del seed estaban hardcodeadas y precargadas en el login: si el panel se publica quedan en texto plano en el bundle apuntando a usuarios que el seed crea de verdad. Ahora detrás de `import.meta.env.DEV`. Verificado: `grep admin123 dist/assets/*.js` da 0.
- La bandeja rotulaba "Bot / App" en todos los tickets, incluidos los cargados a mano (`reportanteId` es null justamente ahí).
- La bitácora traía 100 filas sin decirlo. Una bitácora que corta en silencio se lee como "no pasó nada más".

## Barrido final

- 37 endpoints de negocio: **todos** con consumidor en el panel o en la app.
- 0 botones sin handler y 0 inputs sin `onChange` en el panel; los 15 `Pressable` de la app con `onPress` (verificado con un parser que respeta las llaves, porque el grep simple daba falsos positivos con las arrow functions del `style`).

## Tests

**112 integración** (eran 90), 15 aislamiento, 39 dominio, 24 messaging y **11 de la cola offline**, más lint y typecheck verdes. Lo nuevo:

- `logica-negocio.test.ts` (47) — pertenencia a varios consorcios, visibilidad por unidad, anonimato en conducta, matriz de invitación de inquilinos, aislamiento entre administraciones, gates de rol, máquina de estados, idempotencia y el circuito de sanciones. Fija por escrito lo que verifiqué a mano: la verificación manual caduca, RF-B09 ya se rompió una vez dos commits después de que la probara.
- `bot-flujo.test.ts` (15) — la lógica de conversación del bot, que era el módulo con menos cobertura del repo (10%): teléfono desconocido, teléfono cargado en dos administraciones (que no se rutea a ninguna, a propósito), vínculo dado de baja, confirmación previa, rechazo, corrección de texto, elección entre consorcios y dedup.
- `offline-queue.test.ts` (11) — requirió montar vitest en mobile: el script era `echo 'mobile tests added in Phase 4'`, así que **CI reportaba la app en verde sin ejecutar nada**. De paso el lint pasa a cubrir `app/`: era `eslint src`, así que ninguna pantalla se había linteado nunca.

## Pendiente a propósito

RF-E05 push: `registerPushToken` existe y no se llama de ningún lado, y `expo-notifications` no está en dependencies. Es la tarea 4.4 y no la doy por hecha porque no puedo verificarla sin dispositivo ni proyecto EAS.
